### PR TITLE
Add Default Query for Each Query Type

### DIFF
--- a/src/datasource/components/QueryEditor/QueryEditor.tsx
+++ b/src/datasource/components/QueryEditor/QueryEditor.tsx
@@ -8,7 +8,7 @@ import {
 import { QueryEditorProps } from '@grafana/data';
 
 import { DataSource } from '../../datasource';
-import { Query, QueryType } from '../../types/query';
+import { DEFAULT_QUERIES, Query, QueryType } from '../../types/query';
 import { DataSourceOptions } from '../../types/settings';
 import { KubernetesLogs } from './KubernetesLogs';
 import { KubernetesResources } from './KubernetesResources';
@@ -34,8 +34,8 @@ export function QueryEditor({
   const onTypeChange = (option: ComboboxOption<QueryType>) => {
     onChange({
       ...query,
+      ...DEFAULT_QUERIES[option.value],
       queryType: option.value,
-      resource: '',
     });
     onRunQuery();
   };

--- a/src/datasource/types/query.ts
+++ b/src/datasource/types/query.ts
@@ -7,9 +7,39 @@ import { DataQuery } from '@grafana/schema';
  */
 export const DEFAULT_QUERY: Partial<Query> = {
   queryType: 'kubernetes-resources',
-  namespace: 'default',
   resource: 'pods',
+  namespace: 'default',
   wide: false,
+};
+
+/**
+ * DEFAULT_QUERIES provides default values for each query type. This is used
+ * when the user changes the query type in the query editor.
+ */
+export const DEFAULT_QUERIES: Record<QueryType, Partial<Query>> = {
+  'kubernetes-resourceids': {},
+  'kubernetes-namespaces': {},
+  'kubernetes-containers': {},
+  'kubernetes-resources': {
+    resource: 'pods',
+    namespace: 'default',
+    wide: false,
+  },
+  'kubernetes-logs': {
+    resource: 'pods',
+    namespace: 'default',
+    wide: false,
+  },
+  'helm-releases': {
+    namespace: 'default',
+  },
+  'helm-release-history': {
+    namespace: 'default',
+  },
+  'flux-resources': {
+    resource: 'kustomizations.kustomize.toolkit.fluxcd.io',
+    namespace: 'default',
+  },
 };
 
 /**


### PR DESCRIPTION
Add a default query for each query type, which is used when the user
changes the query type in the query editor.
