### PR TITLE
Add More Variable Types

### DIFF
--- a/src/datasource/components/VariableQueryEditor/KubernetesContainers.tsx
+++ b/src/datasource/components/VariableQueryEditor/KubernetesContainers.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useState } from 'react';
+
+import { QueryEditorProps } from '@grafana/data';
+import {
+  InlineFieldRow,
+  InlineField,
+  ComboboxOption,
+  Combobox,
+} from '@grafana/ui';
+
+import { DataSource } from '../../datasource';
+import { Query } from '../../types/query';
+import { DataSourceOptions } from '../../types/settings';
+
+interface Props
+  extends QueryEditorProps<DataSource, any, DataSourceOptions, Query> { }
+
+export function KubernetesContainers(props: Props) {
+  const [resources, setResources] = useState<ComboboxOption[]>([]);
+  const [namespaces, setNamespaces] = useState<ComboboxOption[]>([]);
+  const [names, setNames] = useState<ComboboxOption[]>([]);
+  const { datasource, query, onChange } = props;
+
+  /**
+   * Fetch available resource kinds from the datasource, which can then be used
+   * as options in the "resource" field.
+   */
+  useEffect(() => {
+    const fetchResources = async () => {
+      const result = await datasource.metricFindQuery({
+        refId: 'kubernetes-resourceids',
+        queryType: 'kubernetes-resourceids',
+      });
+
+      setResources(
+        result.map((value) => {
+          return { value: value.text };
+        }),
+      );
+    };
+
+    fetchResources();
+  }, [datasource]);
+
+  /**
+   * Fetch available namespaces from the datasource, which can then be used as
+   * options in the "namespace" field.
+   */
+  useEffect(() => {
+    const fetchNamespaces = async () => {
+      const result = await datasource.metricFindQuery({
+        refId: 'kubernetes-namespaces',
+        queryType: 'kubernetes-namespaces',
+      });
+
+      setNamespaces(
+        result.map((value) => {
+          return { value: value.text };
+        }),
+      );
+    };
+
+    fetchNamespaces();
+  }, [datasource]);
+
+  /**
+   * Fetch available names from the datasource, which can then be used as
+   * options in the "name" field.
+   */
+  useEffect(() => {
+    const fetchNames = async () => {
+      const result = await datasource.metricFindQuery({
+        refId: 'kubernetes-resources',
+        queryType: 'kubernetes-resources',
+        variableField: 'Name',
+        resource: query.resource,
+        namespace: query.namespace,
+      });
+
+      setNames(
+        result.map((value) => {
+          return { value: value.text };
+        }),
+      );
+    };
+
+    fetchNames();
+  }, [datasource, query.resource, query.namespace]);
+
+  /**
+   * Handle "resource" field change.
+   */
+  const onResourceChange = (option: ComboboxOption<string>) => {
+    onChange({ ...query, resource: option.value });
+  };
+
+  /**
+   * Handle "namespace" field change.
+   */
+  const onNamespaceChange = (option: ComboboxOption<string>) => {
+    onChange({ ...query, namespace: option.value });
+  };
+
+  /**
+   * Handle "name" field change.
+   */
+  const onNameChange = (option: ComboboxOption<string>) => {
+    onChange({ ...query, name: option.value });
+  };
+
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField label="Resource">
+          <Combobox<string>
+            value={query.resource}
+            createCustomValue={true}
+            options={resources}
+            onChange={onResourceChange}
+          />
+        </InlineField>
+        <InlineField label="Namespace">
+          <Combobox<string>
+            value={query.namespace}
+            createCustomValue={true}
+            options={namespaces}
+            onChange={onNamespaceChange}
+          />
+        </InlineField>
+        <InlineField label="Name">
+          <Combobox<string>
+            value={query.name}
+            createCustomValue={true}
+            options={names}
+            onChange={onNameChange}
+          />
+        </InlineField>
+      </InlineFieldRow>
+    </>
+  );
+}

--- a/src/datasource/components/VariableQueryEditor/KubernetesResources.tsx
+++ b/src/datasource/components/VariableQueryEditor/KubernetesResources.tsx
@@ -1,0 +1,115 @@
+import React, { ChangeEvent, useEffect, useState } from 'react';
+
+import { QueryEditorProps } from '@grafana/data';
+import {
+  InlineFieldRow,
+  InlineField,
+  Input,
+  ComboboxOption,
+  Combobox,
+} from '@grafana/ui';
+
+import { DataSource } from '../../datasource';
+import { Query } from '../../types/query';
+import { DataSourceOptions } from '../../types/settings';
+
+interface Props
+  extends QueryEditorProps<DataSource, any, DataSourceOptions, Query> { }
+
+export function KubernetesResources(props: Props) {
+  const [resources, setResources] = useState<ComboboxOption[]>([]);
+  const [namespaces, setNamespaces] = useState<ComboboxOption[]>([]);
+  const { datasource, query, onChange } = props;
+
+  /**
+   * Fetch available resource kinds from the datasource, which can then be used
+   * as options in the "resource" field.
+   */
+  useEffect(() => {
+    const fetchResources = async () => {
+      const result = await datasource.metricFindQuery({
+        refId: 'kubernetes-resourceids',
+        queryType: 'kubernetes-resourceids',
+      });
+
+      setResources(
+        result.map((value) => {
+          return { value: value.text };
+        }),
+      );
+    };
+
+    fetchResources();
+  }, [datasource]);
+
+  /**
+   * Fetch available namespaces from the datasource, which can then be used as
+   * options in the "namespace" field.
+   */
+  useEffect(() => {
+    const fetchNamespaces = async () => {
+      const result = await datasource.metricFindQuery({
+        refId: 'kubernetes-namespaces',
+        queryType: 'kubernetes-namespaces',
+      });
+
+      setNamespaces(
+        result.map((value) => {
+          return { value: value.text };
+        }),
+      );
+    };
+
+    fetchNamespaces();
+  }, [datasource]);
+
+  /**
+   * Handle "resource" field change.
+   */
+  const onResourceChange = (option: ComboboxOption<string>) => {
+    onChange({ ...query, resource: option.value });
+  };
+
+  /**
+   * Handle "namespace" field change.
+   */
+  const onNamespaceChange = (option: ComboboxOption<string>) => {
+    onChange({ ...query, namespace: option.value });
+  };
+
+  /**
+   * Handle "variableField" field change.
+   */
+  const onVariableFieldChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...query, variableField: event.target.value });
+  };
+
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField label="Resource">
+          <Combobox<string>
+            value={query.resource}
+            createCustomValue={true}
+            options={resources}
+            onChange={onResourceChange}
+          />
+        </InlineField>
+        <InlineField label="Namespace">
+          <Combobox<string>
+            value={query.namespace}
+            createCustomValue={true}
+            options={namespaces}
+            onChange={onNamespaceChange}
+          />
+        </InlineField>
+        <InlineField label="Field" grow={true}>
+          <Input
+            onChange={onVariableFieldChange}
+            value={query.variableField || ''}
+          />
+        </InlineField>
+      </InlineFieldRow>
+    </>
+  );
+}

--- a/src/datasource/components/VariableQueryEditor/VaraibleQueryEditor.tsx
+++ b/src/datasource/components/VariableQueryEditor/VaraibleQueryEditor.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 
 import { QueryEditorProps } from '@grafana/data';
-import { InlineField, RadioButtonGroup } from '@grafana/ui';
+import {
+  InlineFieldRow,
+  InlineField,
+  Combobox,
+  ComboboxOption,
+} from '@grafana/ui';
 
 import { DataSource } from '../../datasource';
-import { Query, QueryType } from '../../types/query';
+import { DEFAULT_QUERIES, Query, QueryType } from '../../types/query';
 import { DataSourceOptions } from '../../types/settings';
+import { KubernetesResources } from './KubernetesResources';
+import { KubernetesContainers } from './KubernetesContainers';
 
 interface Props
   extends QueryEditorProps<DataSource, any, DataSourceOptions, Query> { }
@@ -14,25 +21,50 @@ export function VariableQueryEditor(props: Props) {
   const { query, onChange } = props;
 
   /**
-   * Handle "queryType" field change. We support "kubernetes-resourceids" and
-   * "kubernetes-namespaces" queries for variables.
+   * Handle "queryType" field change. If the "queryType" is changed we also set
+   * the default queriy for that query tpe.
    */
-  const onTypeChange = (value: QueryType) => {
-    onChange({ ...query, queryType: value });
+  const onTypeChange = (option: ComboboxOption<QueryType>) => {
+    onChange({
+      ...query,
+      ...DEFAULT_QUERIES[option.value],
+      queryType: option.value,
+    });
   };
 
   return (
     <>
-      <InlineField label="Type" labelWidth={20}>
-        <RadioButtonGroup<QueryType>
-          options={[
-            { label: 'Resources', value: 'kubernetes-resourceids' },
-            { label: 'Namespaces', value: 'kubernetes-namespaces' },
-          ]}
-          value={query.queryType}
-          onChange={onTypeChange}
-        />
-      </InlineField>
+      <InlineFieldRow>
+        <InlineField label="Type">
+          <Combobox<QueryType>
+            value={query.queryType}
+            options={[
+              {
+                label: 'Kubernetes: Resources IDs',
+                value: 'kubernetes-resourceids',
+              },
+              {
+                label: 'Kubernetes: Namespaces',
+                value: 'kubernetes-namespaces',
+              },
+              {
+                label: 'Kubernetes: Containers',
+                value: 'kubernetes-containers',
+              },
+              { label: 'Kubernetes: Resources', value: 'kubernetes-resources' },
+            ]}
+            onChange={onTypeChange}
+          />
+        </InlineField>
+      </InlineFieldRow>
+
+      {query.queryType === 'kubernetes-containers' && (
+        <KubernetesContainers {...props} />
+      )}
+
+      {query.queryType === 'kubernetes-resources' && (
+        <KubernetesResources {...props} />
+      )}
     </>
   );
 }

--- a/src/datasource/types/query.ts
+++ b/src/datasource/types/query.ts
@@ -19,22 +19,38 @@ export const DEFAULT_QUERY: Partial<Query> = {
 export const DEFAULT_QUERIES: Record<QueryType, Partial<Query>> = {
   'kubernetes-resourceids': {},
   'kubernetes-namespaces': {},
-  'kubernetes-containers': {},
+  'kubernetes-containers': {
+    resource: 'pods',
+    namespace: 'default',
+    name: '',
+  },
   'kubernetes-resources': {
     resource: 'pods',
     namespace: 'default',
+    parameterName: '',
+    parameterValue: '',
     wide: false,
+    /**
+     * When using the "kubernetes-resources" query type for a Variable, this
+     * defines which field from the resource should be used as the variable
+     * value. The default is "Name", which will return the metadata.name field
+     * from the resource.
+     */
+    variableField: 'Name',
   },
   'kubernetes-logs': {
     resource: 'pods',
     namespace: 'default',
-    wide: false,
+    name: '',
+    container: '',
+    filter: '',
   },
   'helm-releases': {
     namespace: 'default',
   },
   'helm-release-history': {
     namespace: 'default',
+    name: '',
   },
   'flux-resources': {
     resource: 'kustomizations.kustomize.toolkit.fluxcd.io',


### PR DESCRIPTION
Until now only resource ids and namespaces could be used as variables.
Now it is also possible to use resources and containers as variables.

For this we also improved the default queries for all query types.
