### PR TITLE
Add Support to Link Traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ user and proxing the request to the Kubernetes API.
 
 ![Kubeconfig](https://raw.githubusercontent.com/ricoberger/grafana-kubernetes-plugin/refs/heads/main/src/img/screenshots/kubeconfig.png)
 
+### Integrations
+
+Integrations allow you to integrate the Kubernetes datasource with other
+datasources.
+
+To link traces from the Kubernetes logs to a tracing datasource (e.g. Jaeger)
+you have to enable the tracing integration an a link to the tracing datasource.
+Within the link you can use the `${__value.raw}` variable which will be replaced
+with the actual trace id. To link to a Jaeger datasource the following link can
+be used:
+`/explore?schemaVersion=1&panes={"ao9":{"datasource":"jaeger","queries":[{"query":"${__value.raw}","refId":"A"}]}}`.
+
 ## Contributing
 
 If you want to contribute to the project, please read through the

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
       GF_PATHS_CONFIG: /etc/grafana/provisioning/custom.ini
     volumes:
       - ./kubeconfig-grafana.yaml:/kubeconfig-grafana.yaml
+    extra_hosts:
+      - host.docker.internal:host-gateway
     depends_on:
       - jaeger
       - k3s-kubeconfig

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -24,6 +24,8 @@ type PluginSettings struct {
 	GenerateKubeconfigName string                `json:"generateKubeconfigName"`
 	GenerateKubeconfigTTL  int64                 `json:"generateKubeconfigTTL"`
 	GenerateKubeconfigPort int64                 `json:"generateKubeconfigPort"`
+	IntegrationsTraces     bool                  `json:"integrationsTraces"`
+	IntegrationsTracesLink string                `json:"integrationsTracesLink"`
 	Secrets                *SecretPluginSettings `json:"-"`
 }
 

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -20,6 +20,8 @@ datasources:
       generateKubeconfigName: grafana
       generateKubeconfigTTL: 604800
       generateKubeconfigPort: 11716
+      integrationsTraces: true
+      integrationsTracesLink: /explore?schemaVersion=1&panes={"ao9":{"datasource":"jaeger","queries":[{"query":"$${__value.raw}","refId":"A"}]}}
     secureJsonData:
       clusterKubeconfig:
       grafanaPassword: admin
@@ -27,4 +29,7 @@ datasources:
     type: jaeger
     uid: jaeger
     url: http://jaeger:16686
+    # To use a Jaeger instance running on the host machine, uncomment the line
+    # below and comment out the line above.
+    # url: http://host.docker.internal:16686
     access: proxy

--- a/src/datasource/components/ConfigEditor/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor/ConfigEditor.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../types/settings';
 import { Cluster } from './Cluster';
 import { Impersonate } from './Impersonate';
+import { Integrations } from './Integrations';
 import { GenerateKubeconfig } from './GenerateKubeconfig';
 import { Grafana } from './Grafana';
 
@@ -23,6 +24,7 @@ export function ConfigEditor(props: Props) {
       <Grafana {...props} />
       <Impersonate {...props} />
       <GenerateKubeconfig {...props} />
+      <Integrations {...props} />
     </>
   );
 }

--- a/src/datasource/components/ConfigEditor/Integrations.tsx
+++ b/src/datasource/components/ConfigEditor/Integrations.tsx
@@ -1,0 +1,75 @@
+import React, { ChangeEvent } from 'react';
+import { InlineField, InlineSwitch, Input, useStyles2 } from '@grafana/ui';
+import {
+  DataSourcePluginOptionsEditorProps,
+  GrafanaTheme2,
+} from '@grafana/data';
+import { css } from '@emotion/css';
+
+import {
+  DataSourceOptions,
+  KubernetesSecureJsonData,
+} from '../../types/settings';
+
+interface Props
+  extends DataSourcePluginOptionsEditorProps<
+    DataSourceOptions,
+    KubernetesSecureJsonData
+  > { }
+
+export function Integrations(props: Props) {
+  const styles = useStyles2(getStyles);
+  const { onOptionsChange, options } = props;
+  const { jsonData } = options;
+
+  return (
+    <div className={styles.containerKubeconfigGeneration}>
+      <h3>Integrations</h3>
+      <InlineField label="Traces" labelWidth={20}>
+        <InlineSwitch
+          value={jsonData.integrationsTraces || false}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            onOptionsChange({
+              ...options,
+              jsonData: {
+                ...jsonData,
+                integrationsTraces: event.target.checked,
+                integrationsTracesLink: !event.target.checked
+                  ? ''
+                  : jsonData.integrationsTracesLink,
+              },
+            });
+          }}
+        />
+      </InlineField>
+      <InlineField
+        label="Traces link"
+        labelWidth={20}
+        interactive
+        disabled={!jsonData.integrationsTraces}
+      >
+        <Input
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            onOptionsChange({
+              ...options,
+              jsonData: {
+                ...jsonData,
+                integrationsTracesLink: event.target.value,
+              },
+            });
+          }}
+          value={jsonData.integrationsTracesLink}
+          width={65}
+        />
+      </InlineField>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    containerKubeconfigGeneration: css({
+      paddingTop: theme.spacing(5),
+    }),
+  };
+};

--- a/src/datasource/components/Kubernetes/Kubernetes.tsx
+++ b/src/datasource/components/Kubernetes/Kubernetes.tsx
@@ -47,3 +47,44 @@ export const kubernetesResourcesTransformation = (
     ],
   };
 };
+
+export const kubernetesLogsTransformation = (
+  frame: DataFrame,
+  tracesLink: string,
+) => {
+  const labels = frame.fields.find((field) => field.name === 'labels')?.values;
+  if (!labels) {
+    return frame;
+  }
+
+  return {
+    ...frame,
+    fields: [
+      ...frame.fields,
+      {
+        name: 'traceID',
+        type: FieldType.string,
+        values: labels.map((labels) => {
+          for (const [key, value] of Object.entries(labels)) {
+            if (key.toLowerCase() === 'traceid') {
+              return value;
+            } else if (key.toLowerCase() === 'trace_id') {
+              return value;
+            }
+          }
+
+          return null;
+        }),
+        config: {
+          links: [
+            {
+              title: 'Trace',
+              url: tracesLink,
+              targetBlank: true,
+            },
+          ],
+        },
+      },
+    ],
+  };
+};

--- a/src/datasource/types/settings.ts
+++ b/src/datasource/types/settings.ts
@@ -23,6 +23,8 @@ export interface DataSourceOptions extends DataSourceJsonData {
   generateKubeconfigName?: string;
   generateKubeconfigTTL?: number;
   generateKubeconfigPort?: number;
+  integrationsTraces?: boolean;
+  integrationsTracesLink?: string;
 }
 
 export interface KubernetesSecureJsonData {


### PR DESCRIPTION
It is now possible to link traces within the datasource configuration.
This means whenever a log line contains a trace id, it will be linked to
the tracing provider configured by the user.
