### PR TITLE
Replace Link with Query in Traces Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,12 @@ you have to enable the tracing integration an a link to the tracing datasource.
 Within the link you can use the `${__value.raw}` variable which will be replaced
 with the actual trace id. To link to a Jaeger datasource the following link can
 be used:
-`/explore?schemaVersion=1&panes={"ao9":{"datasource":"jaeger","queries":[{"query":"${__value.raw}","refId":"A"}]}}`.
+
+To view the traces of your Kubernetes logs you have to provide a query for your
+traces. In the query you can use the `${__value.raw}` variable which will be
+replaced with the actual trace id. For example, the following query can be used
+to link to a Jaeger datasource:
+`{"datasource":"jaeger","queries":[{"query":"${__value.raw}","refId":"A"}]}`.
 
 ![Metrics](https://raw.githubusercontent.com/ricoberger/grafana-kubernetes-plugin/refs/heads/main/src/img/screenshots/kubernetes-resources-metrics.png)
 

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -28,7 +28,7 @@ type PluginSettings struct {
 	IntegrationsMetricsKubeletJob          string                `json:"integrationsMetricsKubeletJob"`
 	IntegrationsMetricsKubeStateMetricsJob string                `json:"integrationsMetricsKubeStateMetricsJob"`
 	IntegrationsMetricsNodeExporterJob     string                `json:"integrationsMetricsNodeExporterJob"`
-	IntegrationsTracesLink                 string                `json:"integrationsTracesLink"`
+	IntegrationsTracesQuery                string                `json:"integrationsTracesQuery"`
 	Secrets                                *SecretPluginSettings `json:"-"`
 }
 

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -24,7 +24,7 @@ datasources:
       integrationsMetricsKubeletJob: kubelet
       integrationsMetricsKubeStateMetricsJob: kube-state-metrics
       integrationsMetricsNodeExporterJob: node-exporter
-      integrationsTracesLink: /explore?schemaVersion=1&panes={"ao9":{"datasource":"jaeger","queries":[{"query":"$${__value.raw}","refId":"A"}]}}
+      integrationsTracesQuery: '{"datasource":"jaeger","queries":[{"query":"$${__value.raw}","refId":"A"}]}'
     secureJsonData:
       clusterKubeconfig:
       grafanaPassword: admin

--- a/src/datasource/components/ConfigEditor/Integrations.tsx
+++ b/src/datasource/components/ConfigEditor/Integrations.tsx
@@ -93,18 +93,18 @@ export function Integrations(props: Props) {
           width={65}
         />
       </InlineField>
-      <InlineField label="Traces link" labelWidth={30} interactive>
+      <InlineField label="Traces query" labelWidth={30} interactive>
         <Input
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             onOptionsChange({
               ...options,
               jsonData: {
                 ...jsonData,
-                integrationsTracesLink: event.target.value,
+                integrationsTracesQuery: event.target.value,
               },
             });
           }}
-          value={jsonData.integrationsTracesLink}
+          value={jsonData.integrationsTracesQuery}
           width={65}
         />
       </InlineField>

--- a/src/datasource/components/Kubernetes/Actions.tsx
+++ b/src/datasource/components/Kubernetes/Actions.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { IconButton, Menu, WithContextMenu } from '@grafana/ui';
 import { DataFrame } from '@grafana/data';
 
-import datasourcePluginJson from '../../../datasource/plugin.json';
 import { Query } from '../../types/query';
 import { DataSourceOptions } from '../../types/settings';
 import { DeleteAction } from './DeleteAction';
@@ -68,7 +67,7 @@ export function Actions(props: Props) {
                 <Menu.Item
                   label="Logs"
                   target="_blank"
-                  url={`/explore?schemaVersion=1&panes={"ncx":{"datasource":"${datasource}","queries":[{"queryType":"kubernetes-logs","namespace":"${namespace}","resource":"${resource}","parameterName":"","parameterValue":"","wide":false,"refId":"A","datasource":{"type":"${datasourcePluginJson.id}","uid":"${datasource}"},"name":"${name}","container":""}],"range":{"from":"now-1h","to":"now"}}}`}
+                  url={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: datasource, queries: [{ queryType: 'kubernetes-logs', namespace: namespace, resource: resource, refId: 'A', name: name, container: '' }] }))}`}
                 />
               )}
             <Menu.Item label="Edit" onClick={() => setOpen('edit')} />

--- a/src/datasource/components/Kubernetes/DetailsAction.tsx
+++ b/src/datasource/components/Kubernetes/DetailsAction.tsx
@@ -555,7 +555,7 @@ function Selector(props: {
             color="darkgrey"
             text={
               <TextLink
-                href={`/explore?schemaVersion=1&panes={"ncx":{"datasource":"${props.datasource}","queries":[{"queryType":"kubernetes-resources","namespace":"${props.namespace}","resource":"pods","parameterName":"labelSelector","parameterValue":"${key}=${props.selector.matchLabels ? props.selector.matchLabels[key] : ''}","wide":false,"refId":"A","datasource":{"type":"${datasourcePluginJson.id}","uid":"${props.datasource}"}}],"range":{"from":"now-1h","to":"now"}}}`}
+                href={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: props.datasource, queries: [{ queryType: 'kubernetes-resources', namespace: props.namespace, resource: 'pods', parameterName: 'labelSelector', parameterValue: `${key}=${props.selector.matchLabels ? props.selector.matchLabels[key] : ''}`, wide: false, refId: 'A' }] }))}`}
                 color="secondary"
                 variant="bodySmall"
               >
@@ -857,7 +857,7 @@ function Pod(props: PodProps) {
         <DefinitionItem label="Node">
           {props.manifest.spec?.nodeName ? (
             <TextLink
-              href={`/explore?schemaVersion=1&panes={"ncx":{"datasource":"${props.datasource}","queries":[{"queryType":"kubernetes-resources","namespace":"${props.namespace}","resource":"nodes","parameterName":"fieldSelector","parameterValue":"metadata.name=${props.manifest.spec.nodeName}","wide":false,"refId":"A","datasource":{"type":"${datasourcePluginJson.id}","uid":"${props.datasource}"}}],"range":{"from":"now-1h","to":"now"}}}`}
+              href={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: props.datasource, queries: [{ queryType: 'kubernetes-resources', namespace: props.namespace, resource: 'nodes', parameterName: 'fieldSelector', parameterValue: `metadata.name=${props.manifest.spec.nodeName}`, wide: false, refId: 'A' }] }))}`}
               color="secondary"
               variant="body"
             >

--- a/src/datasource/components/Kubernetes/Kubernetes.tsx
+++ b/src/datasource/components/Kubernetes/Kubernetes.tsx
@@ -53,7 +53,7 @@ export const kubernetesResourcesTransformation = (
 
 export const kubernetesLogsTransformation = (
   frame: DataFrame,
-  tracesLink: string,
+  tracesQuery: string,
 ) => {
   const labels = frame.fields.find((field) => field.name === 'labels')?.values;
   if (!labels) {
@@ -82,7 +82,7 @@ export const kubernetesLogsTransformation = (
           links: [
             {
               title: 'Trace',
-              url: tracesLink,
+              url: `/explore?left=${tracesQuery}`,
               targetBlank: true,
             },
           ],

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -86,11 +86,11 @@ export class DataSource extends DataSourceWithBackend<
               );
             } else if (
               query?.queryType === 'kubernetes-logs' &&
-              this.settings?.integrationsTracesLink
+              this.settings?.integrationsTracesQuery
             ) {
               return kubernetesLogsTransformation(
                 frame,
-                this.settings.integrationsTracesLink,
+                this.settings.integrationsTracesQuery,
               );
             } else if (
               request.app !== CoreApp.Explore &&

--- a/src/datasource/types/settings.ts
+++ b/src/datasource/types/settings.ts
@@ -27,7 +27,7 @@ export interface DataSourceOptions extends DataSourceJsonData {
   integrationsMetricsKubeletJob?: string;
   integrationsMetricsKubeStateMetricsJob?: string;
   integrationsMetricsNodeExporterJob?: string;
-  integrationsTracesLink?: string;
+  integrationsTracesQuery?: string;
 }
 
 export interface KubernetesSecureJsonData {


### PR DESCRIPTION
Instead of linking to a traces datasource like Jaeger in the traces
integration, we now require a query in the Kubernetes datasource
settings.

This commit also improves the linking to the explore view for logs,
nodes and pods by using the same query mechanism.
