### PR TITLE
Improve Logs and Error Handling

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,8 @@ services:
       GF_AUTH_BASIC_ENABLED: true
       GF_PATHS_CONFIG: /etc/grafana/provisioning/custom.ini
     volumes:
-      - ./kubeconfig-grafana.yaml:/kubeconfig-grafana.yaml
+      # - ./kubeconfig-grafana.yaml:/kubeconfig-grafana.yaml
+      - /Users/ricoberger/.kube/config:/kubeconfig-grafana.yaml
     extra_hosts:
       - host.docker.internal:host-gateway
     depends_on:

--- a/pkg/kubernetes/server.go
+++ b/pkg/kubernetes/server.go
@@ -32,15 +32,15 @@ type server struct {
 // If the server can not be started an error is returned. If the server is
 // stopped via the "Stop" method no error is returned.
 func (s *server) Start() error {
-	s.logger.Info("Start server.", "address", s.server.Addr)
+	s.logger.Info("Start server", "address", s.server.Addr)
 
 	if err := s.server.ListenAndServe(); err != nil {
 		if errors.Is(err, http.ErrServerClosed) {
-			s.logger.Debug("Server closed.")
+			s.logger.Debug("Server closed")
 			return nil
 		}
 
-		s.logger.Error("Server died unexpected.", "error", err.Error())
+		s.logger.Error("Server died unexpected", "error", err.Error())
 		return err
 	}
 
@@ -54,11 +54,11 @@ func (s *server) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	s.logger.Debug("Start shutdown of the server.")
+	s.logger.Debug("Start shutdown of the server")
 
 	err := s.server.Shutdown(ctx)
 	if err != nil {
-		s.logger.Error("Graceful shutdown of the server failed.", "error", err.Error())
+		s.logger.Error("Graceful shutdown of the server failed", "error", err.Error())
 		return err
 	}
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -44,25 +44,25 @@ func NewDatasource(ctx context.Context, pCtx backend.DataSourceInstanceSettings)
 	}
 
 	logger := backend.Logger.With("datasource", pCtx.Name).With("datasourceId", pCtx.ID).With("datasourceUid", pCtx.UID).With("instanceId", instanceId.String())
-	logger.Debug("Creating new datasource instance.")
+	logger.Debug("Creating new datasource instance")
 
 	// Load the data source configuration and create the Grafana and Kubernetes
 	// clients.
 	config, err := models.LoadPluginSettings(pCtx)
 	if err != nil {
-		logger.Error("Failed to load plugin settings.", "error", err.Error())
+		logger.Error("Failed to load plugin settings", "error", err.Error())
 		return nil, err
 	}
 
 	grafanaClient, err := grafana.NewClient(ctx, config.ImpersonateUser, config.ImpersonateGroups, config.GrafanaUsername, config.Secrets.GrafanaPassword)
 	if err != nil {
-		logger.Error("Failed to create Grafana client.", "error", err.Error())
+		logger.Error("Failed to create Grafana client", "error", err.Error())
 		return nil, err
 	}
 
 	kubeClient, err := kubernetes.NewClient(ctx, config, logger)
 	if err != nil {
-		logger.Error("Failed to create Kubernets client.", "error", err.Error())
+		logger.Error("Failed to create Kubernets client", "error", err.Error())
 		return nil, err
 	}
 
@@ -78,14 +78,14 @@ func NewDatasource(ctx context.Context, pCtx backend.DataSourceInstanceSettings)
 	if config.GenerateKubeconfig {
 		kubeServer, err = kubernetes.NewServer(config.GenerateKubeconfigPort, kubeClient, grafanaClient, logger)
 		if err != nil {
-			logger.Error("Failed to create Kubernets server.", "error", err.Error())
+			logger.Error("Failed to create Kubernets server", "error", err.Error())
 			return nil, err
 		}
 
 		go func() {
 			for {
 				if err := kubeServer.Start(); err != nil {
-					logger.Debug("Failed to start Kubernets server.", "error", err.Error())
+					logger.Debug("Failed to start Kubernets server", "error", err.Error())
 					time.Sleep(1 * time.Second)
 					continue
 				}
@@ -152,7 +152,7 @@ func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRe
 
 	err := d.kubeClient.CheckHealth(ctx)
 	if err != nil {
-		d.logger.Error("Data source is not working, failed to get namespaces.", "error", err)
+		d.logger.Error("Data source is not working, failed to get namespaces", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -162,7 +162,7 @@ func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRe
 		}, nil
 	}
 
-	d.logger.Debug("Data source is working.")
+	d.logger.Debug("Data source is working")
 
 	return &backend.CheckHealthResult{
 		Status:  backend.HealthStatusOk,
@@ -196,7 +196,7 @@ func (d *Datasource) CallResource(ctx context.Context, req *backend.CallResource
 // old datasource instance will be disposed and a new one will be created using
 // NewSampleDatasource factory function.
 func (d *Datasource) Dispose() {
-	d.logger.Debug("Dispose datasource instance.")
+	d.logger.Debug("Dispose datasource instance")
 
 	// If the generate Kubeconfig feature is enabled and a new Kubernetes server
 	// was created, we stop the server when the data source instance is

--- a/pkg/plugin/helm.go
+++ b/pkg/plugin/helm.go
@@ -29,7 +29,7 @@ func (d *Datasource) handleHelmReleases(ctx context.Context, query concurrent.Qu
 
 	user, err := d.grafanaClient.GetImpersonateUser(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get user.", "error", err.Error())
+		d.logger.Error("Failed to get user", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -37,7 +37,7 @@ func (d *Datasource) handleHelmReleases(ctx context.Context, query concurrent.Qu
 
 	groups, err := d.grafanaClient.GetImpersonateGroups(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get groups.", "error", err.Error())
+		d.logger.Error("Failed to get groups", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -46,7 +46,7 @@ func (d *Datasource) handleHelmReleases(ctx context.Context, query concurrent.Qu
 	var qm models.QueryModelHelmReleases
 	err = json.Unmarshal(query.DataQuery.JSON, &qm)
 	if err != nil {
-		d.logger.Error("Failed to unmarshal query model.", "error", err.Error())
+		d.logger.Error("Failed to unmarshal query model", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -60,7 +60,7 @@ func (d *Datasource) handleHelmReleases(ctx context.Context, query concurrent.Qu
 	restConfig := d.kubeClient.RestConfig()
 	helmClient, err := helm.NewClient(user, groups, qm.Namespace, &restConfig, d.logger)
 	if err != nil {
-		d.logger.Error("Failed to create Helm client.", "error", err.Error())
+		d.logger.Error("Failed to create Helm client", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -68,7 +68,7 @@ func (d *Datasource) handleHelmReleases(ctx context.Context, query concurrent.Qu
 
 	frame, err := helmClient.ListReleases()
 	if err != nil {
-		d.logger.Error("Failed to get Helm releases.", "error", err.Error())
+		d.logger.Error("Failed to get Helm releases", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -93,7 +93,7 @@ func (d *Datasource) handleHelmReleaseHistory(ctx context.Context, query concurr
 
 	user, err := d.grafanaClient.GetImpersonateUser(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get user.", "error", err.Error())
+		d.logger.Error("Failed to get user", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -101,7 +101,7 @@ func (d *Datasource) handleHelmReleaseHistory(ctx context.Context, query concurr
 
 	groups, err := d.grafanaClient.GetImpersonateGroups(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get groups.", "error", err.Error())
+		d.logger.Error("Failed to get groups", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -110,7 +110,7 @@ func (d *Datasource) handleHelmReleaseHistory(ctx context.Context, query concurr
 	var qm models.QueryModelHelmReleaseHistory
 	err = json.Unmarshal(query.DataQuery.JSON, &qm)
 	if err != nil {
-		d.logger.Error("Failed to unmarshal query model.", "error", err.Error())
+		d.logger.Error("Failed to unmarshal query model", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -125,7 +125,7 @@ func (d *Datasource) handleHelmReleaseHistory(ctx context.Context, query concurr
 	restConfig := d.kubeClient.RestConfig()
 	helmClient, err := helm.NewClient(user, groups, qm.Namespace, &restConfig, d.logger)
 	if err != nil {
-		d.logger.Error("Failed to create Helm client.", "error", err.Error())
+		d.logger.Error("Failed to create Helm client", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -133,7 +133,7 @@ func (d *Datasource) handleHelmReleaseHistory(ctx context.Context, query concurr
 
 	frame, err := helmClient.ListReleaseHistory(qm.Name)
 	if err != nil {
-		d.logger.Error("Failed to get Helm release history.", "error", err.Error())
+		d.logger.Error("Failed to get Helm release history", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -154,7 +154,7 @@ func (d *Datasource) handleHelmGetRelease(w http.ResponseWriter, r *http.Request
 
 	version, err := strconv.ParseInt(r.PathValue("version"), 10, 64)
 	if err != nil {
-		d.logger.Error("Failed to parse release version.", "error", err.Error())
+		d.logger.Error("Failed to parse release version", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -164,7 +164,7 @@ func (d *Datasource) handleHelmGetRelease(w http.ResponseWriter, r *http.Request
 
 	user, err := d.grafanaClient.GetImpersonateUser(ctx, r.Header)
 	if err != nil {
-		d.logger.Error("Failed to get user.", "error", err.Error())
+		d.logger.Error("Failed to get user", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -174,7 +174,7 @@ func (d *Datasource) handleHelmGetRelease(w http.ResponseWriter, r *http.Request
 
 	groups, err := d.grafanaClient.GetImpersonateGroups(ctx, r.Header)
 	if err != nil {
-		d.logger.Error("Failed to get groups.", "error", err.Error())
+		d.logger.Error("Failed to get groups", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -192,7 +192,7 @@ func (d *Datasource) handleHelmGetRelease(w http.ResponseWriter, r *http.Request
 	restConfig := d.kubeClient.RestConfig()
 	helmClient, err := helm.NewClient(user, groups, namespace, &restConfig, d.logger)
 	if err != nil {
-		d.logger.Error("Failed to create Helm client.", "error", err.Error())
+		d.logger.Error("Failed to create Helm client", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -202,7 +202,7 @@ func (d *Datasource) handleHelmGetRelease(w http.ResponseWriter, r *http.Request
 
 	release, err := helmClient.GetRelease(name, version)
 	if err != nil {
-		d.logger.Error("Failed to get Helm release.", "error", err.Error())
+		d.logger.Error("Failed to get Helm release", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -229,7 +229,7 @@ func (d *Datasource) handleHelmRollback(w http.ResponseWriter, r *http.Request) 
 
 	version, err := strconv.ParseInt(r.PathValue("version"), 10, 64)
 	if err != nil {
-		d.logger.Error("Failed to parse release version.", "error", err.Error())
+		d.logger.Error("Failed to parse release version", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -239,7 +239,7 @@ func (d *Datasource) handleHelmRollback(w http.ResponseWriter, r *http.Request) 
 
 	user, err := d.grafanaClient.GetImpersonateUser(ctx, r.Header)
 	if err != nil {
-		d.logger.Error("Failed to get user.", "error", err.Error())
+		d.logger.Error("Failed to get user", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -249,7 +249,7 @@ func (d *Datasource) handleHelmRollback(w http.ResponseWriter, r *http.Request) 
 
 	groups, err := d.grafanaClient.GetImpersonateGroups(ctx, r.Header)
 	if err != nil {
-		d.logger.Error("Failed to get groups.", "error", err.Error())
+		d.logger.Error("Failed to get groups", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -267,7 +267,7 @@ func (d *Datasource) handleHelmRollback(w http.ResponseWriter, r *http.Request) 
 	var options helm.RollbackOptions
 	err = json.NewDecoder(r.Body).Decode(&options)
 	if err != nil {
-		d.logger.Error("Failed to unmarshal options.", "error", err.Error())
+		d.logger.Error("Failed to unmarshal options", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -278,7 +278,7 @@ func (d *Datasource) handleHelmRollback(w http.ResponseWriter, r *http.Request) 
 	restConfig := d.kubeClient.RestConfig()
 	helmClient, err := helm.NewClient(user, groups, namespace, &restConfig, d.logger)
 	if err != nil {
-		d.logger.Error("Failed to create Helm client.", "error", err.Error())
+		d.logger.Error("Failed to create Helm client", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -288,7 +288,7 @@ func (d *Datasource) handleHelmRollback(w http.ResponseWriter, r *http.Request) 
 
 	err = helmClient.RollbackRelease(name, version, options)
 	if err != nil {
-		d.logger.Error("Failed to rollback Helm release.", "error", err.Error())
+		d.logger.Error("Failed to rollback Helm release", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -306,7 +306,7 @@ func (d *Datasource) handleHelmUninstall(w http.ResponseWriter, r *http.Request)
 
 	version, err := strconv.ParseInt(r.PathValue("version"), 10, 64)
 	if err != nil {
-		d.logger.Error("Failed to parse release version.", "error", err.Error())
+		d.logger.Error("Failed to parse release version", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -316,7 +316,7 @@ func (d *Datasource) handleHelmUninstall(w http.ResponseWriter, r *http.Request)
 
 	user, err := d.grafanaClient.GetImpersonateUser(ctx, r.Header)
 	if err != nil {
-		d.logger.Error("Failed to get user.", "error", err.Error())
+		d.logger.Error("Failed to get user", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -326,7 +326,7 @@ func (d *Datasource) handleHelmUninstall(w http.ResponseWriter, r *http.Request)
 
 	groups, err := d.grafanaClient.GetImpersonateGroups(ctx, r.Header)
 	if err != nil {
-		d.logger.Error("Failed to get groups.", "error", err.Error())
+		d.logger.Error("Failed to get groups", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -344,7 +344,7 @@ func (d *Datasource) handleHelmUninstall(w http.ResponseWriter, r *http.Request)
 	var options helm.UninstallOptions
 	err = json.NewDecoder(r.Body).Decode(&options)
 	if err != nil {
-		d.logger.Error("Failed to unmarshal options.", "error", err.Error())
+		d.logger.Error("Failed to unmarshal options", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -355,7 +355,7 @@ func (d *Datasource) handleHelmUninstall(w http.ResponseWriter, r *http.Request)
 	restConfig := d.kubeClient.RestConfig()
 	helmClient, err := helm.NewClient(user, groups, namespace, &restConfig, d.logger)
 	if err != nil {
-		d.logger.Error("Failed to create Helm client.", "error", err.Error())
+		d.logger.Error("Failed to create Helm client", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
@@ -365,7 +365,7 @@ func (d *Datasource) handleHelmUninstall(w http.ResponseWriter, r *http.Request)
 
 	info, err := helmClient.UninstallRelease(name, options)
 	if err != nil {
-		d.logger.Error("Failed to uninstall Helm release.", "error", err.Error())
+		d.logger.Error("Failed to uninstall Helm release", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 

--- a/pkg/plugin/kubernetes.go
+++ b/pkg/plugin/kubernetes.go
@@ -34,7 +34,7 @@ func (d *Datasource) handleKubernetesResourceIds(ctx context.Context, query conc
 
 	frame, err := d.kubeClient.GetResourceIds(ctx)
 	if err != nil {
-		d.logger.Error("Failed to get resource kinds.", "error", err.Error())
+		d.logger.Error("Failed to get resource ids", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -61,7 +61,7 @@ func (d *Datasource) handleKubernetesNamespaces(ctx context.Context, query concu
 
 	frame, err := d.kubeClient.GetNamespaces(ctx)
 	if err != nil {
-		d.logger.Error("Failed to get namespaces.", "error", err.Error())
+		d.logger.Error("Failed to get namespaces", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -88,7 +88,7 @@ func (d *Datasource) handleKubernetesResources(ctx context.Context, query concur
 
 	user, err := d.grafanaClient.GetImpersonateUser(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get user.", "error", err.Error())
+		d.logger.Error("Failed to get user", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -96,7 +96,7 @@ func (d *Datasource) handleKubernetesResources(ctx context.Context, query concur
 
 	groups, err := d.grafanaClient.GetImpersonateGroups(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get groups.", "error", err.Error())
+		d.logger.Error("Failed to get groups", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -105,7 +105,7 @@ func (d *Datasource) handleKubernetesResources(ctx context.Context, query concur
 	var qm models.QueryModelKubernetesResources
 	err = json.Unmarshal(query.DataQuery.JSON, &qm)
 	if err != nil {
-		d.logger.Error("Failed to unmarshal query model.", "error", err.Error())
+		d.logger.Error("Failed to unmarshal query model", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -122,7 +122,7 @@ func (d *Datasource) handleKubernetesResources(ctx context.Context, query concur
 
 	frame, err := d.kubeClient.GetResources(ctx, user, groups, qm.Resource, qm.Namespace, qm.ParameterName, qm.ParameterValue, qm.Wide)
 	if err != nil {
-		d.logger.Error("Failed to get resource kinds.", "error", err.Error())
+		d.logger.Error("Failed to get resources", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -150,7 +150,7 @@ func (d *Datasource) handleKubernetesContainers(ctx context.Context, query concu
 
 	user, err := d.grafanaClient.GetImpersonateUser(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get user.", "error", err.Error())
+		d.logger.Error("Failed to get user", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -158,7 +158,7 @@ func (d *Datasource) handleKubernetesContainers(ctx context.Context, query concu
 
 	groups, err := d.grafanaClient.GetImpersonateGroups(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get groups.", "error", err.Error())
+		d.logger.Error("Failed to get groups", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -167,7 +167,7 @@ func (d *Datasource) handleKubernetesContainers(ctx context.Context, query concu
 	var qm models.QueryModelKubernetesContainers
 	err = json.Unmarshal(query.DataQuery.JSON, &qm)
 	if err != nil {
-		d.logger.Error("Failed to unmarshal query model.", "error", err.Error())
+		d.logger.Error("Failed to unmarshal query model", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -182,7 +182,7 @@ func (d *Datasource) handleKubernetesContainers(ctx context.Context, query concu
 
 	frame, err := d.kubeClient.GetContainers(ctx, user, groups, qm.Resource, qm.Namespace, qm.Name)
 	if err != nil {
-		d.logger.Error("Failed to get containers.", "error", err.Error())
+		d.logger.Error("Failed to get containers", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -209,7 +209,7 @@ func (d *Datasource) handleKubernetesLogs(ctx context.Context, query concurrent.
 
 	user, err := d.grafanaClient.GetImpersonateUser(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get user.", "error", err.Error())
+		d.logger.Error("Failed to get user", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -217,7 +217,7 @@ func (d *Datasource) handleKubernetesLogs(ctx context.Context, query concurrent.
 
 	groups, err := d.grafanaClient.GetImpersonateGroups(ctx, query.Headers)
 	if err != nil {
-		d.logger.Error("Failed to get groups.", "error", err.Error())
+		d.logger.Error("Failed to get groups", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -226,7 +226,7 @@ func (d *Datasource) handleKubernetesLogs(ctx context.Context, query concurrent.
 	var qm models.QueryModelKubernetesLogs
 	err = json.Unmarshal(query.DataQuery.JSON, &qm)
 	if err != nil {
-		d.logger.Error("Failed to unmarshal query model.", "error", err.Error())
+		d.logger.Error("Failed to unmarshal query model", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)
@@ -243,7 +243,7 @@ func (d *Datasource) handleKubernetesLogs(ctx context.Context, query concurrent.
 
 	frame, err := d.kubeClient.GetLogs(ctx, user, groups, qm.Resource, qm.Namespace, qm.Name, qm.Container, qm.Filter, query.DataQuery.TimeRange)
 	if err != nil {
-		d.logger.Error("Failed to get logs.", "error", err.Error())
+		d.logger.Error("Failed to get logs", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return backend.ErrorResponseWithErrorSource(err)

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -12,9 +12,9 @@ datasources:
     jsonData:
       clusterProvider: path
       clusterPath: /kubeconfig-grafana.yaml
-      clusterContext: default
+      clusterContext: grafana
       grafanaUsername: admin
-      impersonateUser: false
+      impersonateUser: true
       impersonateGroups: false
       generateKubeconfig: true
       generateKubeconfigName: grafana


### PR DESCRIPTION
Unify the logs, by using the same style for messages and the same field
for errors.

Improve the error handling for getting resources, by returning the error
message, when the list of resources is empty and when there is at least
one error.
