### PR TITLE
Add Kubeconfig Name as Prefix for User in Kubeconfig

### DIFF
--- a/pkg/plugin/kubernetes.go
+++ b/pkg/plugin/kubernetes.go
@@ -340,13 +340,13 @@ func (d *Datasource) handleKubernetesKubeconfig(w http.ResponseWriter, r *http.R
 			Name: d.generateKubeconfigName,
 			Context: clientcmdapiv1.Context{
 				Cluster:   d.generateKubeconfigName,
-				AuthInfo:  user,
+				AuthInfo:  fmt.Sprintf("%s-%s", d.generateKubeconfigName, user),
 				Namespace: "default",
 			},
 		}},
 		CurrentContext: d.generateKubeconfigName,
 		AuthInfos: []clientcmdapiv1.NamedAuthInfo{{
-			Name: user,
+			Name: fmt.Sprintf("%s-%s", d.generateKubeconfigName, user),
 			AuthInfo: clientcmdapiv1.AuthInfo{
 				// Token: token,
 				Exec: &clientcmdapiv1.ExecConfig{


### PR DESCRIPTION
If the plugin is used across multiple Grafana instances, the generated
Kubeconfig files always have the same user name. If a user then wants to
merge all the Kubeconfig files into a single one, a wrong token is used
in the Kubeconfig.
