### PR TITLE
Fix Namespace used for Pod Top Query

### DIFF
--- a/src/datasource/components/Kubernetes/DetailsAction.tsx
+++ b/src/datasource/components/Kubernetes/DetailsAction.tsx
@@ -430,7 +430,7 @@ function DetailsActionTop(props: DetailsActionTopProps) {
           props.resource === 'nodes'
             ? 'nodes.metrics.k8s.io'
             : 'pods.metrics.k8s.io',
-        namespace: selector ? props.namespace : '*',
+        namespace: props.resource === 'nodes' ? '*' : props.namespace,
         parameterName: selector ? 'labelSelector' : 'fieldSelector',
         parameterValue: selector
           ? selector


### PR DESCRIPTION
The namespace was `*` when the top metrics were queried for Pods,
because the selector was empty. Instead of checking the selector we are
now using the requested resource (`pods` or `nodes`) to determine if the
namespace should be set in the query.
