### PR TITLE
Fix Datasource Configuration

### DIFF
--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -14,7 +14,7 @@ datasources:
       clusterPath: /kubeconfig-grafana.yaml
       clusterContext: default
       grafanaUsername: admin
-      impersonateUser: true
+      impersonateUser: false
       impersonateGroups: false
       generateKubeconfig: true
       generateKubeconfigName: grafana


### PR DESCRIPTION
Fix the configuration of the provisioned datasource, so that it can be
directly used, without requiring to deploy additional Kubernetes
manifests (RBAC rules for the `admin` user).
