### PR TITLE
Add AI Action for Helm and Flux Integration

### DIFF
--- a/src/datasource/components/AI/AI.tsx
+++ b/src/datasource/components/AI/AI.tsx
@@ -1,0 +1,172 @@
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Card,
+  Drawer,
+  Field,
+  LoadingPlaceholder,
+  ScrollContainer,
+  Stack,
+  TextArea,
+  useStyles2,
+} from '@grafana/ui';
+import { renderTextPanelMarkdown } from '@grafana/data';
+import DangerouslySetHtmlContent from 'dangerously-set-html-content';
+import { css } from '@emotion/css';
+
+import { Message, getReply } from '../../../utils/utils.llm';
+
+interface Props {
+  getInitialMessages: () => Promise<Message[]>;
+  onClose: () => void;
+}
+
+export function AI(props: Props) {
+  const styles = useStyles2(getStyles);
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [prompt, setPrompt] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const submitPrompt = async () => {
+    setMessages((prevMessages) => [
+      ...prevMessages,
+      { hide: false, role: 'user', message: prompt },
+    ]);
+
+    setPrompt('');
+
+    setTimeout(() => {
+      scrollRef.current?.scrollTo(0, scrollRef.current?.scrollHeight);
+    }, 100);
+  };
+
+  useEffect(() => {
+    const setInitialMessages = async () => {
+      try {
+        setIsLoading(true);
+
+        const initialMessages = await props.getInitialMessages();
+
+        setMessages(initialMessages);
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('An unknown error occurred');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    setInitialMessages();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const fetchReply = async () => {
+      try {
+        if (
+          messages.length === 0 ||
+          messages[messages.length - 1].role === 'assistant'
+        ) {
+          return;
+        }
+
+        setIsLoading(true);
+
+        const reply = await getReply(messages);
+        setMessages((prevMessages) => [...prevMessages, reply]);
+
+        setTimeout(() => {
+          scrollRef.current?.scrollTo(0, scrollRef.current?.scrollHeight);
+        }, 100);
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('An unknown error occurred');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchReply();
+  }, [messages]);
+
+  return (
+    <Drawer
+      title="AI"
+      scrollableContent={false}
+      onClose={() => props.onClose()}
+    >
+      <Stack
+        direction="column"
+        gap={2}
+        justifyContent="space-between"
+        height="100%"
+      >
+        <ScrollContainer ref={scrollRef} height="100%">
+          {messages
+            .filter((message) => !message.hide)
+            .map((message, index) => (
+              <Box
+                key={index}
+                paddingRight={message.role === 'assistant' ? 8 : 0}
+                paddingLeft={message.role === 'user' ? 8 : 0}
+              >
+                <Card isCompact={true}>
+                  <DangerouslySetHtmlContent
+                    allowRerender={true}
+                    html={renderTextPanelMarkdown(message.message)}
+                    className="markdown-html"
+                  />
+                </Card>
+              </Box>
+            ))}
+
+          {isLoading && (
+            <LoadingPlaceholder className={styles.loading} text="Thinking..." />
+          )}
+
+          {error && (
+            <Alert severity="error" title="Error fetching AI reply">
+              {error}
+            </Alert>
+          )}
+        </ScrollContainer>
+
+        <div>
+          <Field label="Prompt" disabled={isLoading}>
+            <TextArea
+              rows={3}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && event.shiftKey) {
+                  event.preventDefault();
+                  submitPrompt();
+                }
+              }}
+              value={prompt}
+              onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
+                setPrompt(event.target.value);
+              }}
+            />
+          </Field>
+        </div>
+      </Stack>
+    </Drawer>
+  );
+}
+
+const getStyles = () => {
+  return {
+    loading: css({
+      marginBottom: 0,
+    }),
+  };
+};

--- a/src/datasource/components/Flux/AIAction.tsx
+++ b/src/datasource/components/Flux/AIAction.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { EventsV1EventList } from '@kubernetes/client-node';
 
-import {
-  Logs,
-  getResourceManifest,
-  getEvents,
-  getLogs,
-} from '../../../utils/utils.resource';
+import { getResourceManifest, getEvents } from '../../../utils/utils.resource';
 import { Message, getSystemMessage } from '../../../utils/utils.llm';
 import { KubernetesManifest } from '../../types/kubernetes';
 import { AI } from '../AI/AI';
@@ -33,19 +28,7 @@ export function AIAction(props: Props) {
       props.name,
     );
 
-    let logs: Logs[] = [];
-    try {
-      if (props.resource === 'pods') {
-        logs = await getLogs(
-          props.datasource,
-          props.namespace,
-          props.name,
-          manifest,
-        );
-      }
-    } catch (_) { }
-
-    return [getSystemMessage(), getInitialUserPrompt(manifest, events, logs)];
+    return [getSystemMessage(), getInitialUserPrompt(manifest, events)];
   };
 
   return <AI getInitialMessages={getInitialMessages} onClose={props.onClose} />;
@@ -54,7 +37,6 @@ export function AIAction(props: Props) {
 const getInitialUserPrompt = (
   manifest: KubernetesManifest,
   events: EventsV1EventList,
-  logs: Logs[],
 ): Message => {
   return {
     hide: true,
@@ -62,9 +44,9 @@ const getInitialUserPrompt = (
     message: `
 Hello Site Reliability Engineer Agent,
 
-Can you please analyse the \`${manifest.metadata?.name}\` \`${manifest.kind}\` in the \`${manifest.metadata?.namespace}\`. I need your expertise to analyze the situation and provide actionable recommendations.
+Can you please analyse the Flux \`${manifest.metadata?.name}\` \`${manifest.kind}\` in the \`${manifest.metadata?.namespace}\`. I need your expertise to analyze the situation and provide actionable recommendations.
 
-Below is the Kubernetes manifest for the resource, the latest events associated with the resource${logs.length > 0 ? `, and the corresponding logs from all containers in that pod.` : `.`}
+Below is the Kubernetes manifest for the resource and the latest events associated with the resource.
 
 ---
 
@@ -79,18 +61,6 @@ ${JSON.stringify(manifest)}
 \`\`\`json
 ${JSON.stringify(events)}
 \`\`\`
-
-### **3. Container Logs**
-
-${logs.map(
-      (log) => `
-#### **Logs from \`${log.container}\` container:**
-
-\`\`\`log
-${log.logs}
-\`\`\`
-`,
-    )}
 `,
   };
 };

--- a/src/datasource/components/Helm/AIAction.tsx
+++ b/src/datasource/components/Helm/AIAction.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import { Message, getSystemMessage } from '../../../utils/utils.llm';
+import { AI } from '../AI/AI';
+import { Release } from './types';
+
+interface Props {
+  datasource?: string;
+  namespace?: string;
+  name?: string;
+  version?: number;
+  onClose: () => void;
+}
+
+export function AIAction(props: Props) {
+  const getInitialMessages = async (): Promise<Message[]> => {
+    const response = await fetch(
+      `/api/datasources/uid/${props.datasource}/resources/helm/${props.namespace}/${props.name}/${props.version}`,
+      {
+        method: 'get',
+        headers: {
+          Accept: 'application/json, */*',
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(await response.text());
+    }
+
+    const release = await response.json();
+
+    return [getSystemMessage(), getInitialUserPrompt(release)];
+  };
+
+  return <AI getInitialMessages={getInitialMessages} onClose={props.onClose} />;
+}
+
+const getInitialUserPrompt = (release: Release): Message => {
+  return {
+    hide: true,
+    role: 'user',
+    message: `
+Hello Site Reliability Engineer Agent,
+
+Can you please analyse the Helm release \`${release.name}\` in the \`${release.namespace}\`. I need your expertise to analyze the situation and provide actionable recommendations.
+
+Below is the Kubernetes manifest for the resource and the latest events associated with the resource.
+
+---
+
+### **1. Helm Release Manifest**
+
+\`\`\`json
+${JSON.stringify(release)}
+\`\`\`
+`,
+  };
+};

--- a/src/datasource/components/Helm/Actions.tsx
+++ b/src/datasource/components/Helm/Actions.tsx
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { IconButton, Menu, WithContextMenu } from '@grafana/ui';
 import { DataFrame } from '@grafana/data';
+import { llm } from '@grafana/llm';
 
 import { Query } from '../../types/query';
 import { DetailsAction } from './DetailsAction';
 import { RollbackAction } from './RollbackAction';
 import { UninstallAction } from './UninstallAction';
+import { AIAction } from './AIAction';
 
 interface Props {
   query: Query;
@@ -19,6 +21,7 @@ interface Props {
  */
 export function Actions(props: Props) {
   const [open, setOpen] = useState('');
+  const [isAIEnabled, setIsAIEnabled] = useState(false);
 
   const datasource = props.query.datasource?.uid;
   const namespace = props.frame.fields.find((f) => f.name === 'Namespace')
@@ -30,12 +33,30 @@ export function Actions(props: Props) {
     props.rowIndex
   ];
 
+  /**
+   * If the Grafana LLM plugin is enabled, we set the "isAIEnabled" state to
+   * "true" to render the AI action in the context menu.
+   */
+  useEffect(() => {
+    const checkIsAIEnabled = async () => {
+      try {
+        const enabled = await llm.enabled();
+        setIsAIEnabled(enabled);
+      } catch (_) { }
+    };
+
+    checkIsAIEnabled();
+  }, []);
+
   return (
     <>
       <WithContextMenu
         renderMenuItems={() => (
           <Menu.Group>
             <Menu.Item label="Details" onClick={() => setOpen('details')} />
+            {isAIEnabled && (
+              <Menu.Item label="AI" onClick={() => setOpen('ai')} />
+            )}
             <Menu.Item label="Rollback" onClick={() => setOpen('rollback')} />
             <Menu.Item label="Uninstall" onClick={() => setOpen('uninstall')} />
           </Menu.Group>
@@ -48,6 +69,16 @@ export function Actions(props: Props) {
 
       {open === 'details' && (
         <DetailsAction
+          datasource={datasource}
+          namespace={namespace}
+          name={name}
+          version={version}
+          onClose={() => setOpen('')}
+        />
+      )}
+
+      {open === 'ai' && (
+        <AIAction
           datasource={datasource}
           namespace={namespace}
           name={name}

--- a/src/datasource/components/Kubernetes/Actions.tsx
+++ b/src/datasource/components/Kubernetes/Actions.tsx
@@ -141,7 +141,6 @@ export function Actions(props: Props) {
 
       {open === 'ai' && (
         <AIAction
-          settings={props.settings}
           datasource={datasource}
           resource={resource}
           namespace={namespace}

--- a/src/utils/utils.llm.ts
+++ b/src/utils/utils.llm.ts
@@ -10,7 +10,7 @@ export interface Message {
 export const getSystemMessage = (): Message => {
   return {
     hide: true,
-    role: 'assistant',
+    role: 'system',
     message: `
 You are a highly skilled Site Reliability Engineer (SRE) AI agent with a specialized focus on analyzing and optimizing Kubernetes resources. Your primary objective is to ensure the reliability, scalability, and cost-effectiveness of applications running on Kubernetes clusters. You are proactive, data-driven, and meticulous in your analysis.
 


### PR DESCRIPTION
Add AI action for Helm and Flux integration to troubleshoot failed Helm
releases and Flux resources using AI-generated suggestions.

To reuse the AI action across integrations, a new AI component is
created, which can be used across integrations and by the Kubernetes
resources actions.

This commit also fixes the role of the system prompt which was
`assistant` instead of `system` in the `utils.llm.ts` file.
