### PR TITLE
Use Default Queries in Pages

### DIFF
--- a/src/pages/Flux/fluxScene.ts
+++ b/src/pages/Flux/fluxScene.ts
@@ -15,6 +15,7 @@ import {
 import { VariableSort } from '@grafana/data';
 
 import datasourcePluginJson from '../../datasource/plugin.json';
+import { DEFAULT_QUERIES } from '../../datasource/types/query';
 
 export function fluxScene() {
   const datasourceVariable = new DataSourceVariable({
@@ -26,9 +27,9 @@ export function fluxScene() {
   const resourceVariable = new CustomVariable({
     name: 'resource',
     label: 'Resource',
-    value: 'TODO',
     query:
       'Buckets : buckets.source.toolkit.fluxcd.io, Git Repositories : gitrepositories.source.toolkit.fluxcd.io, Helm Charts : helmcharts.source.toolkit.fluxcd.io, Helm Repositories : helmrepositories.source.toolkit.fluxcd.io, OCI Repositories : ocirepositories.source.toolkit.fluxcd.io, Kustomizations : kustomizations.kustomize.toolkit.fluxcd.io, Helm Releases : helmreleases.helm.toolkit.fluxcd.io, Image Policies : imagepolicies.image.toolkit.fluxcd.io, Image Repositories : imagerepositories.image.toolkit.fluxcd.io, Image Update Automations : imageupdateautomations.image.toolkit.fluxcd.io, Alerts : alerts.notification.toolkit.fluxcd.io, Providers : providers.notification.toolkit.fluxcd.io, Receivers : receivers.notification.toolkit.fluxcd.io,',
+    value: DEFAULT_QUERIES['flux-resources'].resource,
   });
 
   const namespaceVariable = new QueryVariable({
@@ -43,6 +44,7 @@ export function fluxScene() {
       queryType: 'kubernetes-namespaces',
     },
     sort: VariableSort.alphabeticalCaseInsensitiveAsc,
+    value: DEFAULT_QUERIES['flux-resources'].namespace,
   });
 
   const queryRunner = new SceneQueryRunner({

--- a/src/pages/Helm/helmScene.ts
+++ b/src/pages/Helm/helmScene.ts
@@ -14,6 +14,7 @@ import {
 import { VariableSort } from '@grafana/data';
 
 import datasourcePluginJson from '../../datasource/plugin.json';
+import { DEFAULT_QUERIES } from '../../datasource/types/query';
 
 export function helmScene() {
   const datasourceVariable = new DataSourceVariable({
@@ -34,6 +35,7 @@ export function helmScene() {
       queryType: 'kubernetes-namespaces',
     },
     sort: VariableSort.alphabeticalCaseInsensitiveAsc,
+    value: DEFAULT_QUERIES['helm-releases'].namespace,
   });
 
   const queryRunner = new SceneQueryRunner({

--- a/src/pages/Resources/resourcesScene.ts
+++ b/src/pages/Resources/resourcesScene.ts
@@ -14,6 +14,7 @@ import {
 import { VariableSort } from '@grafana/data';
 
 import datasourcePluginJson from '../../datasource/plugin.json';
+import { DEFAULT_QUERIES } from '../../datasource/types/query';
 
 export function resourcesScene() {
   const datasourceVariable = new DataSourceVariable({
@@ -34,6 +35,7 @@ export function resourcesScene() {
       queryType: 'kubernetes-resourceids',
     },
     sort: VariableSort.alphabeticalCaseInsensitiveAsc,
+    value: DEFAULT_QUERIES['kubernetes-resources'].resource,
   });
 
   const namespaceVariable = new QueryVariable({
@@ -48,6 +50,7 @@ export function resourcesScene() {
       queryType: 'kubernetes-namespaces',
     },
     sort: VariableSort.alphabeticalCaseInsensitiveAsc,
+    value: DEFAULT_QUERIES['kubernetes-resources'].namespace,
   });
 
   const queryRunner = new SceneQueryRunner({


### PR DESCRIPTION
We are now using the default queries from the explore view in the
Kubernetes resources, Helm and Flux pages. This ensures consistency
across different sections of the plugin and leverages the existing query
configurations.
