### PR TITLE
Use DiscoveryClient to Get Resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	go.uber.org/mock v0.6.0
 	helm.sh/helm/v3 v3.19.0
 	k8s.io/api v0.34.1
-	k8s.io/apiextensions-apiserver v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
 )
@@ -216,6 +215,7 @@ require (
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/apiserver v0.34.1 // indirect
 	k8s.io/cli-runtime v0.34.0 // indirect
 	k8s.io/component-base v0.34.1 // indirect

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -80,51 +80,9 @@ func TestGetResourceIds(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("should return resource ids data frame", func(t *testing.T) {
-		expectedFrame := data.NewFrame(
-			"Resources",
-			data.NewField("values", nil, []string{
-				"addons.k3s.cattle.io",
-				"clusterrolebindings",
-				"clusterroles",
-				"configmaps",
-				"cronjobs",
-				"daemonsets",
-				"deployments",
-				"endpoints",
-				"etcdsnapshotfiles.k3s.cattle.io",
-				"events",
-				"helmchartconfigs.helm.cattle.io",
-				"helmcharts.helm.cattle.io",
-				"horizontalpodautoscalers",
-				"ingresses",
-				"jobs",
-				"namespaces",
-				"networkpolicies",
-				"nodes",
-				"nodes.metrics.k8s.io",
-				"persistentvolumeclaims",
-				"persistentvolumes",
-				"poddisruptionbudgets",
-				"pods",
-				"pods.metrics.k8s.io",
-				"replicasets",
-				"rolebindings",
-				"roles",
-				"secrets",
-				"serviceaccounts",
-				"services",
-				"statefulsets",
-				"storageclasses",
-			}),
-		)
-		expectedFrame.SetMeta(&data.FrameMeta{
-			PreferredVisualization: data.VisTypeTable,
-			Type:                   data.FrameTypeTable,
-		})
-
 		actualFrame, err := client.GetResourceIds(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, expectedFrame, actualFrame)
+		require.Equal(t, 55, actualFrame.Fields[0].Len())
 	})
 }
 
@@ -198,7 +156,7 @@ func TestGetContainers(t *testing.T) {
 			Type:                   data.FrameTypeTable,
 		})
 
-		actualFrame, err := client.GetContainers(context.Background(), "", nil, "deployments", "default", "echoserver")
+		actualFrame, err := client.GetContainers(context.Background(), "", nil, "deployments.apps", "default", "echoserver")
 		require.NoError(t, err)
 		require.Equal(t, expectedFrame, actualFrame)
 	})
@@ -253,9 +211,9 @@ func TestGetResource(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("should return resource", func(t *testing.T) {
-		actualResource, err := client.GetResource(context.Background(), "deployments")
+		actualResource, err := client.GetResource(context.Background(), "deployments.apps")
 		require.NoError(t, err)
-		require.Equal(t, &Resource{IsCRD: false, Path: "/apis/apps/v1", Resource: "deployments", Scope: "Namespaced"}, actualResource)
+		require.Equal(t, &Resource{Kind: "Deployment", Resource: "deployments", Path: "/apis/apps/v1", Namespaced: true}, actualResource)
 	})
 }
 

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -4,99 +4,47 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/codes"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/version"
 )
 
 func (c *client) getResources(ctx context.Context) (map[string]Resource, error) {
-	ctx, span := tracing.DefaultTracer().Start(ctx, "getResources")
+	_, span := tracing.DefaultTracer().Start(ctx, "getResources")
 	defer span.End()
 
-	// Create a new resources map and initialize the map with all default
-	// resources of the Kubernetes cluster.
 	resources := make(map[string]Resource)
 
-	resources["cronjobs"] = Resource{IsCRD: false, Path: "/apis/batch/v1", Resource: "cronjobs", Scope: "Namespaced"}
-	resources["daemonsets"] = Resource{IsCRD: false, Path: "/apis/apps/v1", Resource: "daemonsets", Scope: "Namespaced"}
-	resources["deployments"] = Resource{IsCRD: false, Path: "/apis/apps/v1", Resource: "deployments", Scope: "Namespaced"}
-	resources["jobs"] = Resource{IsCRD: false, Path: "/apis/batch/v1", Resource: "jobs", Scope: "Namespaced"}
-	resources["pods"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "pods", Scope: "Namespaced"}
-	resources["replicasets"] = Resource{IsCRD: false, Path: "/apis/apps/v1", Resource: "replicasets", Scope: "Namespaced"}
-	resources["statefulsets"] = Resource{IsCRD: false, Path: "/apis/apps/v1", Resource: "statefulsets", Scope: "Namespaced"}
-	resources["endpoints"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "endpoints", Scope: "Namespaced"}
-	resources["horizontalpodautoscalers"] = Resource{IsCRD: false, Path: "/apis/autoscaling/v2", Resource: "horizontalpodautoscalers", Scope: "Namespaced"}
-	resources["ingresses"] = Resource{IsCRD: false, Path: "/apis/networking.k8s.io/v1", Resource: "ingresses", Scope: "Namespaced"}
-	resources["networkpolicies"] = Resource{IsCRD: false, Path: "/apis/networking.k8s.io/v1", Resource: "networkpolicies", Scope: "Namespaced"}
-	resources["services"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "services", Scope: "Namespaced"}
-	resources["configmaps"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "configmaps", Scope: "Namespaced"}
-	resources["persistentvolumeclaims"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "persistentvolumeclaims", Scope: "Namespaced"}
-	resources["persistentvolumes"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "persistentvolumes", Scope: "Cluster"}
-	resources["poddisruptionbudgets"] = Resource{IsCRD: false, Path: "/apis/policy/v1", Resource: "poddisruptionbudgets", Scope: "Namespaced"}
-	resources["secrets"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "secrets", Scope: "Namespaced"}
-	resources["serviceaccounts"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "serviceaccounts", Scope: "Namespaced"}
-	resources["storageclasses"] = Resource{IsCRD: false, Path: "/apis/storage.k8s.io/v1", Resource: "storageclasses", Scope: "Cluster"}
-	resources["clusterrolebindings"] = Resource{IsCRD: false, Path: "/apis/rbac.authorization.k8s.io/v1", Resource: "clusterrolebindings", Scope: "Cluster"}
-	resources["clusterroles"] = Resource{IsCRD: false, Path: "/apis/rbac.authorization.k8s.io/v1", Resource: "clusterroles", Scope: "Cluster"}
-	resources["rolebindings"] = Resource{IsCRD: false, Path: "/apis/rbac.authorization.k8s.io/v1", Resource: "rolebindings", Scope: "Namespaced"}
-	resources["roles"] = Resource{IsCRD: false, Path: "/apis/rbac.authorization.k8s.io/v1", Resource: "roles", Scope: "Namespaced"}
-	resources["events"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "events", Scope: "Namespaced"}
-	resources["namespaces"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "namespaces", Scope: "Cluster"}
-	resources["nodes"] = Resource{IsCRD: false, Path: "/api/v1", Resource: "nodes", Scope: "Cluster"}
-	resources["pods.metrics.k8s.io"] = Resource{IsCRD: false, Path: "/apis/metrics.k8s.io/v1beta1", Resource: "pods", Scope: "Namespaced"}
-	resources["nodes.metrics.k8s.io"] = Resource{IsCRD: false, Path: "/apis/metrics.k8s.io/v1beta1", Resource: "nodes", Scope: "Cluster"}
-
-	// Get all CustomResourceDefinitions deployed in the Kubernetes cluster and
-	// add them to the resources map. The key in the map for the resources is
-	// the plural name of the CustomResourceDefinition and the API group, which
-	// should be unique accross all CRDs.
-	res, err := c.clientset.CoreV1().RESTClient().Get().AbsPath("apis/apiextensions.k8s.io/v1/customresourcedefinitions").DoRaw(ctx)
+	lists, err := c.discoveryClient.ServerPreferredResources()
 	if err != nil {
+		c.logger.Error("Failed to supported resources", "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		return nil, err
 	}
 
-	var crdList apiextensionsv1.CustomResourceDefinitionList
+	for _, list := range lists {
+		if len(list.APIResources) == 0 {
+			continue
+		}
 
-	err = json.Unmarshal(res, &crdList)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return nil, err
-	}
-
-	for _, crd := range crdList.Items {
-		if len(crd.Spec.Versions) > 0 {
-			sort.Slice(crd.Spec.Versions, func(i, j int) bool {
-				return version.CompareKubeAwareVersionStrings(crd.Spec.Versions[i].Name, crd.Spec.Versions[j].Name) > 0
-			})
-
-			var columns []Column
-			if crd.Spec.Versions[0].AdditionalPrinterColumns != nil {
-				for _, column := range crd.Spec.Versions[0].AdditionalPrinterColumns {
-					if column.Priority == 0 {
-						columns = append(columns, Column{
-							Description: column.Description,
-							JSONPath:    column.JSONPath,
-							Name:        column.Name,
-							Type:        column.Type,
-						})
-					}
-				}
+		for _, resource := range list.APIResources {
+			pathPrefix := "/apis"
+			if list.GroupVersion == "v1" {
+				pathPrefix = "/api"
 			}
 
-			resources[fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, crd.Spec.Group)] = Resource{
-				IsCRD:    true,
-				Path:     fmt.Sprintf("/apis/%s/%s", crd.Spec.Group, crd.Spec.Versions[0].Name),
-				Resource: crd.Spec.Names.Plural,
-				Scope:    string(crd.Spec.Scope),
-				Columns:  columns,
+			id := resource.Name
+			groupVersion := strings.Split(list.GroupVersion, "/")
+			if len(groupVersion) == 2 {
+				id = fmt.Sprintf("%s.%s", resource.Name, groupVersion[0])
+			}
+
+			if slices.Contains(resource.Verbs, "list") {
+				resources[id] = Resource{Kind: resource.Kind, Resource: resource.Name, Path: fmt.Sprintf("%s/%s", pathPrefix, list.GroupVersion), Namespaced: resource.Namespaced}
 			}
 		}
 	}
@@ -108,7 +56,7 @@ func (c *client) getResources(ctx context.Context) (map[string]Resource, error) 
 // data. The resources JSON data is expected to be in the format of a Kubernetes
 // Table object. If the wide parameter is true, all columns are included in the
 // data frame, otherwise only the columns with priority 0 are included.
-func createResourcesDataFrame(resources [][]byte, isNamespaced, wide bool) (*data.Frame, error) {
+func createResourcesDataFrame(resources [][]byte, namespaced, wide bool) (*data.Frame, error) {
 	table := metav1.Table{}
 	frame := data.NewFrame("Resources")
 
@@ -127,7 +75,7 @@ func createResourcesDataFrame(resources [][]byte, isNamespaced, wide bool) (*dat
 
 	// If the resource is a namespaced resource, we include the namespace as
 	// first field in the data frame.
-	if isNamespaced {
+	if namespaced {
 		var values []string
 		for _, row := range table.Rows {
 			var metadata metav1.PartialObjectMetadata

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -11,18 +11,10 @@ import (
 // be able to fetch all resource dynamically from the Kubernetes API, based on
 // the "Path" and "Resource" fields.
 type Resource struct {
-	IsCRD    bool     `json:"isCRD"`
-	Path     string   `json:"path"`
-	Resource string   `json:"resource"`
-	Scope    string   `json:"scope"`
-	Columns  []Column `json:"columns"`
-}
-
-type Column struct {
-	Description string `json:"description"`
-	JSONPath    string `json:"jsonPath"`
-	Name        string `json:"name"`
-	Type        string `json:"type"`
+	Kind       string `json:"kind"`
+	Resource   string `json:"resource"`
+	Path       string `json:"path"`
+	Namespaced bool   `json:"namespaced"`
 }
 
 // Stream represents a logs stream for a single pod. It contains the "Pod" name

--- a/src/datasource/components/Kubernetes/Actions.tsx
+++ b/src/datasource/components/Kubernetes/Actions.tsx
@@ -59,16 +59,22 @@ export function Actions(props: Props) {
             <Menu.Item label="Details" onClick={() => setOpen('details')} />
 
             {resource &&
-              ['deployments', 'statefulsets', 'replicasets'].includes(
-                resource,
-              ) && <Menu.Item label="Scale" onClick={() => setOpen('scale')} />}
+              [
+                'deployments.apps',
+                'statefulsets.apps',
+                'replicasets.apps',
+              ].includes(resource) && (
+                <Menu.Item label="Scale" onClick={() => setOpen('scale')} />
+              )}
             {resource &&
-              ['daemonsets', 'deployments', 'statefulsets'].includes(
-                resource,
-              ) && (
+              [
+                'daemonsets.apps',
+                'deployments.apps',
+                'statefulsets.apps',
+              ].includes(resource) && (
                 <Menu.Item label="Restart" onClick={() => setOpen('restart')} />
               )}
-            {resource && ['cronjobs'].includes(resource) && (
+            {resource && ['cronjobs.batch'].includes(resource) && (
               <Menu.Item
                 label="Create job"
                 onClick={() => setOpen('createjob')}
@@ -76,11 +82,11 @@ export function Actions(props: Props) {
             )}
             {resource &&
               [
-                'daemonsets',
-                'deployments',
-                'jobs',
+                'daemonsets.apps',
+                'deployments.apps',
+                'jobs.batch',
                 'pods',
-                'statefulsets',
+                'statefulsets.apps',
               ].includes(resource) && (
                 <Menu.Item
                   label="Logs"

--- a/src/datasource/components/Kubernetes/DeleteAction.tsx
+++ b/src/datasource/components/Kubernetes/DeleteAction.tsx
@@ -46,7 +46,7 @@ export function DeleteAction(props: Props) {
       const resource = await getResource(props.datasource, props.resource);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.scope === 'Namespaced' ? `/namespaces/${props.namespace}` : ''}/${resource.resource}/${props.name}`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${props.namespace}` : ''}/${resource.resource}/${props.name}`,
         {
           method: 'delete',
           headers: {

--- a/src/datasource/components/Kubernetes/DetailsAction.tsx
+++ b/src/datasource/components/Kubernetes/DetailsAction.tsx
@@ -160,11 +160,11 @@ export function DetailsAction(props: Props) {
               }}
             />
             {[
-              'daemonsets',
-              'deployments',
-              'jobs',
+              'daemonsets.apps',
+              'deployments.apps',
+              'jobs.batch',
               'nodes',
-              'statefulsets',
+              'statefulsets.apps',
             ].includes(props.resource || '') && (
                 <Tab
                   label="Pods"
@@ -176,12 +176,12 @@ export function DetailsAction(props: Props) {
                 />
               )}
             {[
-              'daemonsets',
-              'deployments',
-              'jobs',
+              'daemonsets.apps',
+              'deployments.apps',
+              'jobs.batch',
               'nodes',
               'pods',
-              'statefulsets',
+              'statefulsets.apps',
             ].includes(props.resource || '') && (
                 <Tab
                   label="Top"
@@ -197,15 +197,15 @@ export function DetailsAction(props: Props) {
               props.settings.integrationsMetricsKubeStateMetricsJob &&
               props.settings.integrationsMetricsNodeExporterJob &&
               [
-                'daemonsets',
-                'deployments',
-                'cronjobs',
-                'horizontalpodautoscalers',
-                'jobs',
+                'daemonsets.apps',
+                'deployments.apps',
+                'cronjobs.batch',
+                'horizontalpodautoscalers.autoscaling',
+                'jobs.batch',
                 'nodes',
                 'persistentvolumeclaims',
                 'pods',
-                'statefulsets',
+                'statefulsets.apps',
                 'verticalpodautoscalers.autoscaling.k8s.io',
               ].includes(props.resource || '') && (
                 <Tab
@@ -246,23 +246,25 @@ export function DetailsAction(props: Props) {
 
           {activeTab === 'metrics' && (
             <>
-              {props.resource === 'daemonsets' && (
+              {props.resource === 'daemonsets.apps' && (
                 <MetricsDaemonSets {...props} />
               )}
-              {props.resource === 'deployments' && (
+              {props.resource === 'deployments.apps' && (
                 <MetricsDeployments {...props} />
               )}
-              {props.resource === 'cronjobs' && <MetricsCronJobs {...props} />}
-              {props.resource === 'horizontalpodautoscalers' && (
+              {props.resource === 'cronjobs.batch' && (
+                <MetricsCronJobs {...props} />
+              )}
+              {props.resource === 'horizontalpodautoscalers.autoscaling' && (
                 <MetricsHPAs {...props} />
               )}
-              {props.resource === 'jobs' && <MetricsJobs {...props} />}
+              {props.resource === 'jobs.batch' && <MetricsJobs {...props} />}
               {props.resource === 'nodes' && <MetricsNodes {...props} />}
               {props.resource === 'persistentvolumeclaims' && (
                 <MetricsPersistentVolumeClaims {...props} />
               )}
               {props.resource === 'pods' && <MetricsPods {...props} />}
-              {props.resource === 'statefulsets' && (
+              {props.resource === 'statefulsets.apps' && (
                 <MetricsStatefulSets {...props} />
               )}
               {props.resource ===

--- a/src/datasource/components/Kubernetes/EditAction.tsx
+++ b/src/datasource/components/Kubernetes/EditAction.tsx
@@ -84,7 +84,7 @@ export function EditAction(props: Props) {
       const resource = await getResource(props.datasource, props.resource);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${props.namespace}` : ''}/${resource.resource}/${props.name}`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/RestartAction.tsx
+++ b/src/datasource/components/Kubernetes/RestartAction.tsx
@@ -40,7 +40,7 @@ export function RestartAction(props: Props) {
       const resource = await getResource(props.datasource, props.resource);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.scope === 'Namespaced' ? `/namespaces/${props.namespace}` : ''}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${props.namespace}` : ''}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/types/kubernetes.ts
+++ b/src/datasource/types/kubernetes.ts
@@ -5,18 +5,10 @@ import { KubernetesObject } from '@kubernetes/client-node';
  * fields to identify and work with this resource.
  */
 export interface Resource {
-  isCRD: boolean;
-  path: string;
+  kind: string;
   resource: string;
-  scope: 'Cluster' | 'Namespaced';
-  columns: ResourceColumn[] | null;
-}
-
-export interface ResourceColumn {
-  description: string;
-  jsonPath: string;
-  name: string;
-  type: string;
+  path: string;
+  namespaced: boolean;
 }
 
 export interface KubernetesManifest extends KubernetesObject {

--- a/src/utils/utils.resource.ts
+++ b/src/utils/utils.resource.ts
@@ -33,7 +33,7 @@ export const getResourceManifest = async (
   const resource = await getResource(datasource, resourceId);
 
   const response = await fetch(
-    `/api/datasources/uid/${datasource}/resources/kubernetes/proxy${resource.path}${resource.scope === 'Namespaced' ? `/namespaces/${namespace}` : ''}/${resource.resource}/${name}`,
+    `/api/datasources/uid/${datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${namespace}` : ''}/${resource.resource}/${name}`,
     {
       method: 'get',
       headers: {


### PR DESCRIPTION
Instead of maintaining our own list of supported resources and getting a
list of CustomResourceDefinitions we are now using the DiscoveryClient
to get the list of supported resources from the Kubernetes API server.
This simplifies the code and ensures we always have an up-tp-date list
of resources.
