### PR TITLE
Add Label to Kubernetes Resources Queries

### DIFF
--- a/pkg/kubernetes/cache.go
+++ b/pkg/kubernetes/cache.go
@@ -10,7 +10,7 @@ import (
 // by its ID, and set all resources at once.
 type Cache interface {
 	IsValid() bool
-	GetKeys() []string
+	GetKeysAndKinds() ([]string, []string)
 	Get(id string) (Resource, bool)
 	SetAll(resources map[string]Resource)
 }
@@ -33,15 +33,17 @@ func (c *cache) IsValid() bool {
 	return true
 }
 
-func (c *cache) GetKeys() []string {
+func (c *cache) GetKeysAndKinds() ([]string, []string) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
 	var keys []string
-	for k := range c.resources {
+	var kinds []string
+	for k, v := range c.resources {
 		keys = append(keys, k)
+		kinds = append(kinds, v.Kind)
 	}
-	return keys
+	return keys, kinds
 }
 
 func (c *cache) Get(id string) (Resource, bool) {

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -110,13 +110,14 @@ func (c *client) GetResourceIds(ctx context.Context) (*data.Frame, error) {
 
 	c.refreshCache(ctx)
 
-	// Get a list of all resource ids, which are all the keys in the cache.
-	keys := c.cache.GetKeys()
-	slices.Sort(keys)
+	// Get a list of all resource ids, which are all the keys in the cache and a
+	// list of all kinds.
+	keys, kinds := c.cache.GetKeysAndKinds()
 
 	frame := data.NewFrame(
 		"Resources",
 		data.NewField("values", nil, keys),
+		data.NewField("kinds", nil, kinds),
 	)
 
 	frame.SetMeta(&data.FrameMeta{

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -83,6 +83,7 @@ func TestGetResourceIds(t *testing.T) {
 		actualFrame, err := client.GetResourceIds(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, 55, actualFrame.Fields[0].Len())
+		require.Equal(t, 55, actualFrame.Fields[1].Len())
 	})
 }
 

--- a/provisioning/dashboards/kubernetes/kubernetes-workloads.json
+++ b/provisioning/dashboards/kubernetes/kubernetes-workloads.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
+  "id": 1,
   "links": [],
   "panels": [
     {
@@ -143,8 +143,8 @@
       {
         "allowCustomValue": false,
         "current": {
-          "text": "deployments",
-          "value": "deployments"
+          "text": "Deployment",
+          "value": "deployments.apps"
         },
         "description": "",
         "label": "Resource",
@@ -152,31 +152,31 @@
         "options": [
           {
             "selected": false,
-            "text": "DaemonSets",
-            "value": "daemonsets"
+            "text": "DaemonSet",
+            "value": "daemonsets.apps"
           },
           {
             "selected": true,
-            "text": "Deployments",
-            "value": "deployments"
+            "text": "Deployment",
+            "value": "deployments.apps"
           },
           {
             "selected": false,
-            "text": "Pods",
+            "text": "Pod",
             "value": "pods"
           },
           {
             "selected": false,
-            "text": "Jobs",
-            "value": "jobs"
+            "text": "Job",
+            "value": "jobs.batch"
           },
           {
             "selected": false,
-            "text": "StatefulSets",
-            "value": "statefulsets"
+            "text": "StatefulSet",
+            "value": "statefulsets.apps"
           }
         ],
-        "query": "DaemonSets : daemonsets, Deployments : deployments, Pods : pods, Jobs : jobs, StatefulSets : statefulsets",
+        "query": "DaemonSet : daemonsets.apps, Deployment : deployments.apps, Pod : pods, Job : jobs.batch, StatefulSet : statefulsets.apps",
         "type": "custom"
       },
       {

--- a/src/datasource/components/QueryEditor/FluxResources.tsx
+++ b/src/datasource/components/QueryEditor/FluxResources.tsx
@@ -73,55 +73,55 @@ export function FluxResources({
             createCustomValue={true}
             options={[
               {
-                label: 'Buckets',
+                label: 'Bucket',
                 value: 'buckets.source.toolkit.fluxcd.io',
               },
               {
-                label: 'Git Repositories',
+                label: 'GitRepository',
                 value: 'gitrepositories.source.toolkit.fluxcd.io',
               },
               {
-                label: 'Helm Charts',
+                label: 'HelmChart',
                 value: 'helmcharts.source.toolkit.fluxcd.io',
               },
               {
-                label: 'Helm Repositories',
+                label: 'HelmRepository',
                 value: 'helmrepositories.source.toolkit.fluxcd.io',
               },
               {
-                label: 'OCI Repositories',
+                label: 'OCIRepository',
                 value: 'ocirepositories.source.toolkit.fluxcd.io',
               },
               {
-                label: 'Kustomizations',
+                label: 'Kustomization',
                 value: 'kustomizations.kustomize.toolkit.fluxcd.io',
               },
               {
-                label: 'Helm Releases',
+                label: 'HelmRelease',
                 value: 'helmreleases.helm.toolkit.fluxcd.io',
               },
               {
-                label: 'Image Policies',
+                label: 'ImagePolicy',
                 value: 'imagepolicies.image.toolkit.fluxcd.io',
               },
               {
-                label: 'Image Repositories',
+                label: 'ImageRepository',
                 value: 'imagerepositories.image.toolkit.fluxcd.io',
               },
               {
-                label: 'Image Update Automations',
+                label: 'ImageUpdateAutomation',
                 value: 'imageupdateautomations.image.toolkit.fluxcd.io',
               },
               {
-                label: 'Alerts',
+                label: 'Alert',
                 value: 'alerts.notification.toolkit.fluxcd.io',
               },
               {
-                label: 'Providers',
+                label: 'Provider',
                 value: 'providers.notification.toolkit.fluxcd.io',
               },
               {
-                label: 'Receivers',
+                label: 'Receiver',
                 value: 'receivers.notification.toolkit.fluxcd.io',
               },
             ]}

--- a/src/datasource/components/QueryEditor/KubernetesLogs.tsx
+++ b/src/datasource/components/QueryEditor/KubernetesLogs.tsx
@@ -169,11 +169,11 @@ export function KubernetesLogs({
             value={query.resource}
             createCustomValue={true}
             options={[
-              { value: 'daemonsets' },
-              { value: 'deployments' },
-              { value: 'pods' },
-              { value: 'jobs' },
-              { value: 'statefulsets' },
+              { value: 'daemonsets.apps', label: 'DaemonSet' },
+              { value: 'deployments.apps', label: 'Deployment' },
+              { value: 'pods', label: 'Pod' },
+              { value: 'jobs.batch', label: 'Job' },
+              { value: 'statefulsets.apps', label: 'StatefulSet' },
             ]}
             onChange={onResourceChange}
           />

--- a/src/datasource/components/QueryEditor/KubernetesResources.tsx
+++ b/src/datasource/components/QueryEditor/KubernetesResources.tsx
@@ -38,7 +38,7 @@ export function KubernetesResources({
 
       setResources(
         result.map((value) => {
-          return { value: value.text };
+          return { value: value.value as string, label: value.text };
         }),
       );
     };

--- a/src/datasource/components/VariableQueryEditor/KubernetesContainers.tsx
+++ b/src/datasource/components/VariableQueryEditor/KubernetesContainers.tsx
@@ -34,7 +34,7 @@ export function KubernetesContainers(props: Props) {
 
       setResources(
         result.map((value) => {
-          return { value: value.text };
+          return { value: value.value as string, label: value.text };
         }),
       );
     };

--- a/src/datasource/components/VariableQueryEditor/KubernetesResources.tsx
+++ b/src/datasource/components/VariableQueryEditor/KubernetesResources.tsx
@@ -34,7 +34,7 @@ export function KubernetesResources(props: Props) {
 
       setResources(
         result.map((value) => {
-          return { value: value.text };
+          return { value: value.value as string, label: value.text };
         }),
       );
     };

--- a/src/pages/Flux/fluxScene.ts
+++ b/src/pages/Flux/fluxScene.ts
@@ -28,7 +28,7 @@ export function fluxScene() {
     name: 'resource',
     label: 'Resource',
     query:
-      'Buckets : buckets.source.toolkit.fluxcd.io, Git Repositories : gitrepositories.source.toolkit.fluxcd.io, Helm Charts : helmcharts.source.toolkit.fluxcd.io, Helm Repositories : helmrepositories.source.toolkit.fluxcd.io, OCI Repositories : ocirepositories.source.toolkit.fluxcd.io, Kustomizations : kustomizations.kustomize.toolkit.fluxcd.io, Helm Releases : helmreleases.helm.toolkit.fluxcd.io, Image Policies : imagepolicies.image.toolkit.fluxcd.io, Image Repositories : imagerepositories.image.toolkit.fluxcd.io, Image Update Automations : imageupdateautomations.image.toolkit.fluxcd.io, Alerts : alerts.notification.toolkit.fluxcd.io, Providers : providers.notification.toolkit.fluxcd.io, Receivers : receivers.notification.toolkit.fluxcd.io,',
+      'Bucket : buckets.source.toolkit.fluxcd.io, GitRepository : gitrepositories.source.toolkit.fluxcd.io, HelmChart : helmcharts.source.toolkit.fluxcd.io, HelmRepository : helmrepositories.source.toolkit.fluxcd.io, OCIRepository : ocirepositories.source.toolkit.fluxcd.io, Kustomization : kustomizations.kustomize.toolkit.fluxcd.io, HelmRelease : helmreleases.helm.toolkit.fluxcd.io, ImagePolicy : imagepolicies.image.toolkit.fluxcd.io, ImageRepository : imagerepositories.image.toolkit.fluxcd.io, ImageUpdateAutomation : imageupdateautomations.image.toolkit.fluxcd.io, Alert : alerts.notification.toolkit.fluxcd.io, Provider : providers.notification.toolkit.fluxcd.io, Receiver : receivers.notification.toolkit.fluxcd.io,',
     value: DEFAULT_QUERIES['flux-resources'].resource,
   });
 


### PR DESCRIPTION
When we display a list of Kubernetes resources in the variables
selection, we now include their `kind` as labels. This enhancement
should improve the UI / UX becaue we do not display the raw resource ids
anymore. The ids are still used as value, to identify the correct
resource based on user selection.
