### PR TITLE
Add Action to Suspend and Resume CronJobs

### DIFF
--- a/src/datasource/components/Kubernetes/Actions.tsx
+++ b/src/datasource/components/Kubernetes/Actions.tsx
@@ -12,6 +12,8 @@ import { CreateJobAction } from './CreateJobAction';
 import { EditAction } from './EditAction';
 import { DetailsAction } from './DetailsAction';
 import { AIAction } from './AIAction';
+import { CronJobSuspendAction } from './CronJobSuspendAction';
+import { CronJobResumeAction } from './CronJobResumeAction';
 
 interface Props {
   query: Query;
@@ -80,6 +82,18 @@ export function Actions(props: Props) {
                 onClick={() => setOpen('createjob')}
               />
             )}
+            {resource && ['cronjobs.batch'].includes(resource) && (
+              <Menu.Item
+                label="Suspend"
+                onClick={() => setOpen('cronjobsuspend')}
+              />
+            )}
+            {resource && ['cronjobs.batch'].includes(resource) && (
+              <Menu.Item
+                label="Resume"
+                onClick={() => setOpen('cronjobresume')}
+              />
+            )}
             {resource &&
               [
                 'daemonsets.apps',
@@ -142,6 +156,24 @@ export function Actions(props: Props) {
         namespace={namespace}
         name={name}
         isOpen={open === 'createjob'}
+        onClose={() => setOpen('')}
+      />
+
+      <CronJobSuspendAction
+        datasource={datasource}
+        resource={resource}
+        namespace={namespace}
+        name={name}
+        isOpen={open === 'cronjobsuspend'}
+        onClose={() => setOpen('')}
+      />
+
+      <CronJobResumeAction
+        datasource={datasource}
+        resource={resource}
+        namespace={namespace}
+        name={name}
+        isOpen={open === 'cronjobresume'}
         onClose={() => setOpen('')}
       />
 

--- a/src/datasource/components/Kubernetes/CronJobResumeAction.tsx
+++ b/src/datasource/components/Kubernetes/CronJobResumeAction.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import {
+  ConfirmModal,
+  LoadingPlaceholder,
+  Stack,
+  useStyles2,
+} from '@grafana/ui';
+import { AppEvents, GrafanaTheme2 } from '@grafana/data';
+import { getAppEvents } from '@grafana/runtime';
+import { css } from '@emotion/css';
+
+import { getResource } from '../../../utils/utils.resource';
+
+interface Props {
+  datasource?: string;
+  resource?: string;
+  namespace?: string;
+  name?: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function CronJobResumeAction(props: Props) {
+  const styles = useStyles2(getStyles);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onConfirm = async () => {
+    try {
+      setIsLoading(true);
+
+      const resource = await getResource(props.datasource, props.resource);
+
+      const response = await fetch(
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        {
+          method: 'patch',
+          headers: {
+            Accept: 'application/json, */*',
+            'Content-Type': 'application/merge-patch+json',
+          },
+          body: JSON.stringify({
+            spec: { suspend: false },
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error();
+      }
+
+      const appEvents = getAppEvents();
+      appEvents.publish({
+        type: AppEvents.alertSuccess.name,
+        payload: [`${props.namespace}/${props.name} was resumed`],
+      });
+    } catch (_) {
+      const appEvents = getAppEvents();
+      appEvents.publish({
+        type: AppEvents.alertError.name,
+        payload: [`Failed to resume ${props.namespace}/${props.name}`],
+      });
+    } finally {
+      setIsLoading(false);
+      props.onClose();
+    }
+  };
+
+  return (
+    <ConfirmModal
+      isOpen={props.isOpen}
+      title="Resume cronjob"
+      body={`Are you sure you want to resume ${props.namespace}/${props.name}?`}
+      description={
+        <div className={styles.body}>
+          <Stack direction="column">
+            {isLoading && <LoadingPlaceholder text="Resumeing cronjob..." />}
+          </Stack>
+        </div>
+      }
+      confirmText="Resume"
+      confirmButtonVariant="primary"
+      dismissText="Cancel"
+      onConfirm={onConfirm}
+      onDismiss={() => props.onClose()}
+      disabled={isLoading}
+    />
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    body: css({
+      marginTop: theme.spacing(2),
+    }),
+  };
+};

--- a/src/datasource/components/Kubernetes/CronJobSuspendAction.tsx
+++ b/src/datasource/components/Kubernetes/CronJobSuspendAction.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import {
+  ConfirmModal,
+  LoadingPlaceholder,
+  Stack,
+  useStyles2,
+} from '@grafana/ui';
+import { AppEvents, GrafanaTheme2 } from '@grafana/data';
+import { getAppEvents } from '@grafana/runtime';
+import { css } from '@emotion/css';
+
+import { getResource } from '../../../utils/utils.resource';
+
+interface Props {
+  datasource?: string;
+  resource?: string;
+  namespace?: string;
+  name?: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function CronJobSuspendAction(props: Props) {
+  const styles = useStyles2(getStyles);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onConfirm = async () => {
+    try {
+      setIsLoading(true);
+
+      const resource = await getResource(props.datasource, props.resource);
+
+      const response = await fetch(
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        {
+          method: 'patch',
+          headers: {
+            Accept: 'application/json, */*',
+            'Content-Type': 'application/merge-patch+json',
+          },
+          body: JSON.stringify({
+            spec: { suspend: true },
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error();
+      }
+
+      const appEvents = getAppEvents();
+      appEvents.publish({
+        type: AppEvents.alertSuccess.name,
+        payload: [`${props.namespace}/${props.name} was suspended`],
+      });
+    } catch (_) {
+      const appEvents = getAppEvents();
+      appEvents.publish({
+        type: AppEvents.alertError.name,
+        payload: [`Failed to suspend ${props.namespace}/${props.name}`],
+      });
+    } finally {
+      setIsLoading(false);
+      props.onClose();
+    }
+  };
+
+  return (
+    <ConfirmModal
+      isOpen={props.isOpen}
+      title="Suspend cronjob"
+      body={`Are you sure you want to suspend ${props.namespace}/${props.name}?`}
+      description={
+        <div className={styles.body}>
+          <Stack direction="column">
+            {isLoading && <LoadingPlaceholder text="Suspending cronjob..." />}
+          </Stack>
+        </div>
+      }
+      confirmText="Suspend"
+      confirmButtonVariant="primary"
+      dismissText="Cancel"
+      onConfirm={onConfirm}
+      onDismiss={() => props.onClose()}
+      disabled={isLoading}
+    />
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    body: css({
+      marginTop: theme.spacing(2),
+    }),
+  };
+};


### PR DESCRIPTION
This commits adds two new actions for CronJobs, so that it is now
possible to suspend and resume CronJobs directly from the UI.
