### PR TITLE
Format Metrics in Resources View

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -230,7 +230,7 @@ func (c *client) GetResources(ctx context.Context, user string, groups []string,
 		return nil, errors[0]
 	}
 
-	return createResourcesDataFrame(resources, resource.Namespaced, wide)
+	return createResourcesDataFrame(resourceId, resources, resource.Namespaced, wide)
 }
 
 // GetContainer returns a list of all containers for the requested resource


### PR DESCRIPTION
The `PodMetrics` and `NodeMetrics` are now better formatted in the
resources view. Instead of directly using the result from the Kubernetes
API, we are parsing the returned values and formatting them into the
same format as `kubectl top` does.

This means we are using millicores (`m`) for CPU and mebibytes (`Mi`) for
memory.
