### PR TITLE
Improve Resource Handling

### DIFF
--- a/pkg/kubernetes/cache.go
+++ b/pkg/kubernetes/cache.go
@@ -10,7 +10,7 @@ import (
 // by its ID, and set all resources at once.
 type Cache interface {
 	IsValid() bool
-	GetKeysAndKinds() ([]string, []string)
+	GetDataFrameValues() ([]string, []string, []string, []string, []string, []string)
 	Get(id string) (Resource, bool)
 	SetAll(resources map[string]Resource)
 }
@@ -33,17 +33,30 @@ func (c *cache) IsValid() bool {
 	return true
 }
 
-func (c *cache) GetKeysAndKinds() ([]string, []string) {
+func (c *cache) GetDataFrameValues() ([]string, []string, []string, []string, []string, []string) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	var keys []string
+	var ids []string
 	var kinds []string
-	for k, v := range c.resources {
-		keys = append(keys, k)
+	var names []string
+	var apiVersions []string
+	var paths []string
+	var namespaced []string
+
+	for _, v := range c.resources {
+		ids = append(ids, v.ID)
 		kinds = append(kinds, v.Kind)
+		names = append(names, v.Name)
+		apiVersions = append(apiVersions, v.APIVersion)
+		paths = append(paths, v.Path)
+		if v.Namespaced {
+			namespaced = append(namespaced, "true")
+		} else {
+			namespaced = append(namespaced, "false")
+		}
 	}
-	return keys, kinds
+	return ids, kinds, apiVersions, names, paths, namespaced
 }
 
 func (c *cache) Get(id string) (Resource, bool) {

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -114,7 +114,7 @@ func TestGetResources(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("should return resources nodes data frame", func(t *testing.T) {
-		actualFrame, err := client.GetResources(context.Background(), "", nil, "nodes", "*", "", "", true)
+		actualFrame, err := client.GetResources(context.Background(), "", nil, "node", "*", "", "", true)
 		require.NoError(t, err)
 		require.Equal(t, "Name", actualFrame.Fields[0].Name)
 		require.Equal(t, "Status", actualFrame.Fields[1].Name)
@@ -130,7 +130,7 @@ func TestGetResources(t *testing.T) {
 	})
 
 	t.Run("should return resources pods data frame", func(t *testing.T) {
-		actualFrame, err := client.GetResources(context.Background(), "", nil, "pods", "default", "", "", false)
+		actualFrame, err := client.GetResources(context.Background(), "", nil, "pod", "default", "", "", false)
 		require.NoError(t, err)
 		require.Equal(t, "Namespace", actualFrame.Fields[0].Name)
 		require.Equal(t, "Name", actualFrame.Fields[1].Name)
@@ -157,7 +157,7 @@ func TestGetContainers(t *testing.T) {
 			Type:                   data.FrameTypeTable,
 		})
 
-		actualFrame, err := client.GetContainers(context.Background(), "", nil, "deployments.apps", "default", "echoserver")
+		actualFrame, err := client.GetContainers(context.Background(), "", nil, "deployment.apps", "default", "echoserver")
 		require.NoError(t, err)
 		require.Equal(t, expectedFrame, actualFrame)
 	})
@@ -169,7 +169,7 @@ func TestGetLogs(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("should return logs", func(t *testing.T) {
-		actualLogs, err := client.GetLogs(context.Background(), "", nil, "pods", "default", "echoserver", "echoserver", "", backend.TimeRange{From: time.Now().Add(-1 * time.Hour), To: time.Now().Add(1 * time.Hour)})
+		actualLogs, err := client.GetLogs(context.Background(), "", nil, "pod", "default", "echoserver", "echoserver", "", backend.TimeRange{From: time.Now().Add(-1 * time.Hour), To: time.Now().Add(1 * time.Hour)})
 		require.NoError(t, err)
 		require.Equal(t, "timestamp", actualLogs.Fields[0].Name)
 		require.Equal(t, "body", actualLogs.Fields[1].Name)
@@ -187,7 +187,7 @@ func TestGetLogs(t *testing.T) {
 	})
 
 	t.Run("should return filtered logs", func(t *testing.T) {
-		actualLogs, err := client.GetLogs(context.Background(), "", nil, "pods", "default", "echoserver", "echoserver", "build", backend.TimeRange{From: time.Now().Add(-1 * time.Hour), To: time.Now().Add(1 * time.Hour)})
+		actualLogs, err := client.GetLogs(context.Background(), "", nil, "pod", "default", "echoserver", "echoserver", "build", backend.TimeRange{From: time.Now().Add(-1 * time.Hour), To: time.Now().Add(1 * time.Hour)})
 		require.NoError(t, err)
 		require.Equal(t, "timestamp", actualLogs.Fields[0].Name)
 		require.Equal(t, "body", actualLogs.Fields[1].Name)
@@ -212,9 +212,9 @@ func TestGetResource(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("should return resource", func(t *testing.T) {
-		actualResource, err := client.GetResource(context.Background(), "deployments.apps")
+		actualResource, err := client.GetResource(context.Background(), "deployment.apps")
 		require.NoError(t, err)
-		require.Equal(t, &Resource{Kind: "Deployment", Resource: "deployments", Path: "/apis/apps/v1", Namespaced: true}, actualResource)
+		require.Equal(t, &Resource{ID: "deployment.apps", Kind: "Deployment", APIVersion: "apps/v1", Name: "deployments", Path: "/apis/apps/v1", Namespaced: true}, actualResource)
 	})
 }
 

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -11,8 +11,10 @@ import (
 // be able to fetch all resource dynamically from the Kubernetes API, based on
 // the "Path" and "Resource" fields.
 type Resource struct {
+	ID         string `json:"id"`
 	Kind       string `json:"kind"`
-	Resource   string `json:"resource"`
+	APIVersion string `json:"apiVersion"`
+	Name       string `json:"name"`
 	Path       string `json:"path"`
 	Namespaced bool   `json:"namespaced"`
 }

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -14,7 +14,7 @@ const (
 )
 
 type QueryModelKubernetesResources struct {
-	Resource       string `json:"resource"`
+	ResourceId     string `json:"resourceId"`
 	Namespace      string `json:"namespace"`
 	ParameterName  string `json:"parameterName"`
 	ParameterValue string `json:"parameterValue"`
@@ -22,17 +22,17 @@ type QueryModelKubernetesResources struct {
 }
 
 type QueryModelKubernetesContainers struct {
-	Resource  string `json:"resource"`
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
+	ResourceId string `json:"resourceId"`
+	Namespace  string `json:"namespace"`
+	Name       string `json:"name"`
 }
 
 type QueryModelKubernetesLogs struct {
-	Resource  string `json:"resource"`
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
-	Container string `json:"container"`
-	Filter    string `json:"filter"`
+	ResourceId string `json:"resourceId"`
+	Namespace  string `json:"namespace"`
+	Name       string `json:"name"`
+	Container  string `json:"container"`
+	Filter     string `json:"filter"`
 }
 
 type QueryModelHelmReleases struct {

--- a/pkg/plugin/kubernetes.go
+++ b/pkg/plugin/kubernetes.go
@@ -108,16 +108,16 @@ func (d *Datasource) handleKubernetesResources(ctx context.Context, query concur
 		return backend.ErrorResponseWithErrorSource(err)
 	}
 
-	d.logger.Info("handleKubernetesResources query", "user", user, "groups", groups, "resource", qm.Resource, "namespace", qm.Namespace, "parameterName", qm.ParameterName, "parameterValue", qm.ParameterValue, "wide", qm.Wide)
+	d.logger.Info("handleKubernetesResources query", "user", user, "groups", groups, "resourceId", qm.ResourceId, "namespace", qm.Namespace, "parameterName", qm.ParameterName, "parameterValue", qm.ParameterValue, "wide", qm.Wide)
 	span.SetAttributes(attribute.Key("user").String(user))
 	span.SetAttributes(attribute.Key("groups").StringSlice(groups))
-	span.SetAttributes(attribute.Key("resource").String(qm.Resource))
+	span.SetAttributes(attribute.Key("resourceId").String(qm.ResourceId))
 	span.SetAttributes(attribute.Key("namespace").String(qm.Namespace))
 	span.SetAttributes(attribute.Key("parameterName").String(qm.ParameterName))
 	span.SetAttributes(attribute.Key("parameterValue").String(qm.ParameterValue))
 	span.SetAttributes(attribute.Key("wide").Bool(qm.Wide))
 
-	frame, err := d.kubeClient.GetResources(ctx, user, groups, qm.Resource, qm.Namespace, qm.ParameterName, qm.ParameterValue, qm.Wide)
+	frame, err := d.kubeClient.GetResources(ctx, user, groups, qm.ResourceId, qm.Namespace, qm.ParameterName, qm.ParameterValue, qm.Wide)
 	if err != nil {
 		d.logger.Error("Failed to get resources", "error", err.Error())
 		span.RecordError(err)
@@ -170,14 +170,14 @@ func (d *Datasource) handleKubernetesContainers(ctx context.Context, query concu
 		return backend.ErrorResponseWithErrorSource(err)
 	}
 
-	d.logger.Info("handleKubernetesContainers query", "user", user, "groups", groups, "resource", qm.Resource, "namespace", qm.Namespace, "name", qm.Name)
+	d.logger.Info("handleKubernetesContainers query", "user", user, "groups", groups, "resourceId", qm.ResourceId, "namespace", qm.Namespace, "name", qm.Name)
 	span.SetAttributes(attribute.Key("user").String(user))
 	span.SetAttributes(attribute.Key("groups").StringSlice(groups))
-	span.SetAttributes(attribute.Key("resource").String(qm.Resource))
+	span.SetAttributes(attribute.Key("resourceId").String(qm.ResourceId))
 	span.SetAttributes(attribute.Key("namespace").String(qm.Namespace))
 	span.SetAttributes(attribute.Key("name").String(qm.Name))
 
-	frame, err := d.kubeClient.GetContainers(ctx, user, groups, qm.Resource, qm.Namespace, qm.Name)
+	frame, err := d.kubeClient.GetContainers(ctx, user, groups, qm.ResourceId, qm.Namespace, qm.Name)
 	if err != nil {
 		d.logger.Error("Failed to get containers", "error", err.Error())
 		span.RecordError(err)
@@ -229,16 +229,16 @@ func (d *Datasource) handleKubernetesLogs(ctx context.Context, query concurrent.
 		return backend.ErrorResponseWithErrorSource(err)
 	}
 
-	d.logger.Info("handleKubernetesLogs query", "user", user, "groups", groups, "resource", qm.Resource, "namespace", qm.Namespace, "name", qm.Name, "container", qm.Container, "filter", qm.Filter)
+	d.logger.Info("handleKubernetesLogs query", "user", user, "groups", groups, "resourceId", qm.ResourceId, "namespace", qm.Namespace, "name", qm.Name, "container", qm.Container, "filter", qm.Filter)
 	span.SetAttributes(attribute.Key("user").String(user))
 	span.SetAttributes(attribute.Key("groups").StringSlice(groups))
-	span.SetAttributes(attribute.Key("resource").String(qm.Resource))
+	span.SetAttributes(attribute.Key("resourceId").String(qm.ResourceId))
 	span.SetAttributes(attribute.Key("namespace").String(qm.Namespace))
 	span.SetAttributes(attribute.Key("name").String(qm.Name))
 	span.SetAttributes(attribute.Key("container").String(qm.Container))
 	span.SetAttributes(attribute.Key("filter").String(qm.Filter))
 
-	frame, err := d.kubeClient.GetLogs(ctx, user, groups, qm.Resource, qm.Namespace, qm.Name, qm.Container, qm.Filter, query.DataQuery.TimeRange)
+	frame, err := d.kubeClient.GetLogs(ctx, user, groups, qm.ResourceId, qm.Namespace, qm.Name, qm.Container, qm.Filter, query.DataQuery.TimeRange)
 	if err != nil {
 		d.logger.Error("Failed to get logs", "error", err.Error())
 		span.RecordError(err)

--- a/provisioning/dashboards/kubernetes/kubernetes-workloads.json
+++ b/provisioning/dashboards/kubernetes/kubernetes-workloads.json
@@ -144,7 +144,7 @@
         "allowCustomValue": false,
         "current": {
           "text": "Deployment",
-          "value": "deployments.apps"
+          "value": "deployment.apps"
         },
         "description": "",
         "label": "Resource",
@@ -153,30 +153,30 @@
           {
             "selected": false,
             "text": "DaemonSet",
-            "value": "daemonsets.apps"
+            "value": "daemonset.apps"
           },
           {
             "selected": true,
             "text": "Deployment",
-            "value": "deployments.apps"
+            "value": "deployment.apps"
           },
           {
             "selected": false,
             "text": "Pod",
-            "value": "pods"
+            "value": "pod"
           },
           {
             "selected": false,
             "text": "Job",
-            "value": "jobs.batch"
+            "value": "job.batch"
           },
           {
             "selected": false,
             "text": "StatefulSet",
-            "value": "statefulsets.apps"
+            "value": "statefulset.apps"
           }
         ],
-        "query": "DaemonSet : daemonsets.apps, Deployment : deployments.apps, Pod : pods, Job : jobs.batch, StatefulSet : statefulsets.apps",
+        "query": "DaemonSet : daemonset.apps, Deployment : deployment.apps, Pod : pod, Job : job.batch, StatefulSet : statefulset.apps",
         "type": "custom"
       },
       {

--- a/src/datasource/components/Flux/AIAction.tsx
+++ b/src/datasource/components/Flux/AIAction.tsx
@@ -8,7 +8,7 @@ import { AI } from '../AI/AI';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   onClose: () => void;
@@ -18,7 +18,7 @@ export function AIAction(props: Props) {
   const getInitialMessages = async (): Promise<Message[]> => {
     const manifest = await getResourceManifest(
       props.datasource,
-      props.resource,
+      props.resourceId,
       props.namespace,
       props.name,
     );

--- a/src/datasource/components/Flux/Actions.tsx
+++ b/src/datasource/components/Flux/Actions.tsx
@@ -25,7 +25,7 @@ export function Actions(props: Props) {
   const [isAIEnabled, setIsAIEnabled] = useState(false);
 
   const datasource = props.query.datasource?.uid;
-  const resource = props.query.resource;
+  const resourceId = props.query.resourceId;
   const namespace = props.frame.fields.find((f) => f.name === 'Namespace')
     ?.values[props.rowIndex];
   const name = props.frame.fields.find((f) => f.name === 'Name')?.values[
@@ -56,56 +56,56 @@ export function Actions(props: Props) {
             {isAIEnabled && (
               <Menu.Item label="AI" onClick={() => setOpen('ai')} />
             )}
-            {resource &&
+            {resourceId &&
               [
-                'buckets.source.toolkit.fluxcd.io',
-                'gitrepositories.source.toolkit.fluxcd.io',
-                'helmcharts.source.toolkit.fluxcd.io',
-                'helmrepositories.source.toolkit.fluxcd.io',
-                'ocirepositories.source.toolkit.fluxcd.io',
-                'kustomizations.kustomize.toolkit.fluxcd.io',
-                'helmreleases.helm.toolkit.fluxcd.io',
-                'imagerepositories.image.toolkit.fluxcd.io',
-                'imageupdateautomations.image.toolkit.fluxcd.io',
-                'receivers.notification.toolkit.fluxcd.io',
-              ].includes(resource) && (
+                'bucket.source.toolkit.fluxcd.io',
+                'gitrepositorie.source.toolkit.fluxcd.io',
+                'helmchart.source.toolkit.fluxcd.io',
+                'helmrepository.source.toolkit.fluxcd.io',
+                'ocirepository.source.toolkit.fluxcd.io',
+                'kustomization.kustomize.toolkit.fluxcd.io',
+                'helmrelease.helm.toolkit.fluxcd.io',
+                'imagerepository.image.toolkit.fluxcd.io',
+                'imageupdateautomation.image.toolkit.fluxcd.io',
+                'receiver.notification.toolkit.fluxcd.io',
+              ].includes(resourceId) && (
                 <Menu.Item
                   label="Reconcile"
                   onClick={() => setOpen('reconcile')}
                 />
               )}
-            {resource &&
+            {resourceId &&
               [
-                'buckets.source.toolkit.fluxcd.io',
-                'gitrepositories.source.toolkit.fluxcd.io',
-                'helmcharts.source.toolkit.fluxcd.io',
-                'helmrepositories.source.toolkit.fluxcd.io',
-                'ocirepositories.source.toolkit.fluxcd.io',
-                'kustomizations.kustomize.toolkit.fluxcd.io',
-                'helmreleases.helm.toolkit.fluxcd.io',
-                'imagerepositories.image.toolkit.fluxcd.io',
-                'imageupdateautomations.image.toolkit.fluxcd.io',
-                'alerts.notification.toolkit.fluxcd.io',
-                'providers.notification.toolkit.fluxcd.io',
-                'receivers.notification.toolkit.fluxcd.io',
-              ].includes(resource) && (
+                'bucket.source.toolkit.fluxcd.io',
+                'gitrepository.source.toolkit.fluxcd.io',
+                'helmchart.source.toolkit.fluxcd.io',
+                'helmrepository.source.toolkit.fluxcd.io',
+                'ocirepository.source.toolkit.fluxcd.io',
+                'kustomization.kustomize.toolkit.fluxcd.io',
+                'helmrelease.helm.toolkit.fluxcd.io',
+                'imagerepository.image.toolkit.fluxcd.io',
+                'imageupdateautomation.image.toolkit.fluxcd.io',
+                'alert.notification.toolkit.fluxcd.io',
+                'provider.notification.toolkit.fluxcd.io',
+                'receiver.notification.toolkit.fluxcd.io',
+              ].includes(resourceId) && (
                 <Menu.Item label="Suspend" onClick={() => setOpen('suspend')} />
               )}
-            {resource &&
+            {resourceId &&
               [
-                'buckets.source.toolkit.fluxcd.io',
-                'gitrepositories.source.toolkit.fluxcd.io',
-                'helmcharts.source.toolkit.fluxcd.io',
-                'helmrepositories.source.toolkit.fluxcd.io',
-                'ocirepositories.source.toolkit.fluxcd.io',
-                'kustomizations.kustomize.toolkit.fluxcd.io',
-                'helmreleases.helm.toolkit.fluxcd.io',
-                'imagerepositories.image.toolkit.fluxcd.io',
-                'imageupdateautomations.image.toolkit.fluxcd.io',
-                'alerts.notification.toolkit.fluxcd.io',
-                'providers.notification.toolkit.fluxcd.io',
-                'receivers.notification.toolkit.fluxcd.io',
-              ].includes(resource) && (
+                'bucket.source.toolkit.fluxcd.io',
+                'gitrepository.source.toolkit.fluxcd.io',
+                'helmchart.source.toolkit.fluxcd.io',
+                'helmrepository.source.toolkit.fluxcd.io',
+                'ocirepository.source.toolkit.fluxcd.io',
+                'kustomization.kustomize.toolkit.fluxcd.io',
+                'helmrelease.helm.toolkit.fluxcd.io',
+                'imagerepository.image.toolkit.fluxcd.io',
+                'imageupdateautomation.image.toolkit.fluxcd.io',
+                'alert.notification.toolkit.fluxcd.io',
+                'provider.notification.toolkit.fluxcd.io',
+                'receiver.notification.toolkit.fluxcd.io',
+              ].includes(resourceId) && (
                 <Menu.Item label="Resume" onClick={() => setOpen('resume')} />
               )}
           </Menu.Group>
@@ -119,7 +119,7 @@ export function Actions(props: Props) {
       {open === 'details' && (
         <DetailsAction
           datasource={datasource}
-          resource={resource}
+          resourceId={resourceId}
           namespace={namespace}
           name={name}
           onClose={() => setOpen('')}
@@ -129,7 +129,7 @@ export function Actions(props: Props) {
       {open === 'ai' && (
         <AIAction
           datasource={datasource}
-          resource={resource}
+          resourceId={resourceId}
           namespace={namespace}
           name={name}
           onClose={() => setOpen('')}
@@ -138,7 +138,7 @@ export function Actions(props: Props) {
 
       <ReconcileAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'reconcile'}
@@ -147,7 +147,7 @@ export function Actions(props: Props) {
 
       <SuspendAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'suspend'}
@@ -156,7 +156,7 @@ export function Actions(props: Props) {
 
       <ResumeAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'resume'}

--- a/src/datasource/components/Flux/DetailsAction.tsx
+++ b/src/datasource/components/Flux/DetailsAction.tsx
@@ -37,7 +37,7 @@ initPluginTranslations('ricoberger-kubernetes-app');
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   onClose: () => void;
@@ -65,7 +65,7 @@ export function DetailsAction(props: Props) {
 
         const manifest = await getResourceManifest(
           props.datasource,
-          props.resource,
+          props.resourceId,
           props.namespace,
           props.name,
         );
@@ -82,7 +82,7 @@ export function DetailsAction(props: Props) {
     };
 
     fetchManifest();
-  }, [props.datasource, props.resource, props.namespace, props.name]);
+  }, [props.datasource, props.resourceId, props.namespace, props.name]);
 
   return (
     <Drawer

--- a/src/datasource/components/Flux/ReconcileAction.tsx
+++ b/src/datasource/components/Flux/ReconcileAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -35,10 +35,10 @@ export function ReconcileAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.name}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Flux/ResumeAction.tsx
+++ b/src/datasource/components/Flux/ResumeAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -35,10 +35,10 @@ export function ResumeAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.name}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Flux/SuspendAction.tsx
+++ b/src/datasource/components/Flux/SuspendAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -35,10 +35,10 @@ export function SuspendAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.name}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/AIAction.tsx
+++ b/src/datasource/components/Kubernetes/AIAction.tsx
@@ -13,7 +13,7 @@ import { AI } from '../AI/AI';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   onClose: () => void;
@@ -23,7 +23,7 @@ export function AIAction(props: Props) {
   const getInitialMessages = async (): Promise<Message[]> => {
     const manifest = await getResourceManifest(
       props.datasource,
-      props.resource,
+      props.resourceId,
       props.namespace,
       props.name,
     );
@@ -35,7 +35,7 @@ export function AIAction(props: Props) {
 
     let logs: Logs[] = [];
     try {
-      if (props.resource === 'pods') {
+      if (props.resourceId === 'pod') {
         logs = await getLogs(
           props.datasource,
           props.namespace,

--- a/src/datasource/components/Kubernetes/Actions.tsx
+++ b/src/datasource/components/Kubernetes/Actions.tsx
@@ -36,7 +36,7 @@ export function Actions(props: Props) {
   const [isAIEnabled, setIsAIEnabled] = useState(false);
 
   const datasource = props.query.datasource?.uid;
-  const resource = props.query.resource;
+  const resourceId = props.query.resourceId;
   const namespace = props.frame.fields.find((f) => f.name === 'Namespace')
     ?.values[props.rowIndex];
   const name = props.frame.fields.find((f) => f.name === 'Name')?.values[
@@ -65,76 +65,76 @@ export function Actions(props: Props) {
           <Menu.Group>
             <Menu.Item label="Details" onClick={() => setOpen('details')} />
 
-            {resource &&
+            {resourceId &&
               [
-                'deployments.apps',
-                'statefulsets.apps',
-                'replicasets.apps',
-              ].includes(resource) && (
+                'deployment.apps',
+                'statefulset.apps',
+                'replicaset.apps',
+              ].includes(resourceId) && (
                 <Menu.Item label="Scale" onClick={() => setOpen('scale')} />
               )}
-            {resource &&
+            {resourceId &&
               [
-                'daemonsets.apps',
-                'deployments.apps',
-                'statefulsets.apps',
-              ].includes(resource) && (
+                'daemonset.apps',
+                'deployment.apps',
+                'statefulset.apps',
+              ].includes(resourceId) && (
                 <Menu.Item label="Restart" onClick={() => setOpen('restart')} />
               )}
-            {resource && ['cronjobs.batch'].includes(resource) && (
+            {resourceId && ['cronjob.batch'].includes(resourceId) && (
               <Menu.Item
                 label="Create job"
                 onClick={() => setOpen('createjob')}
               />
             )}
-            {resource && ['cronjobs.batch'].includes(resource) && (
+            {resourceId && ['cronjob.batch'].includes(resourceId) && (
               <Menu.Item
                 label="Suspend"
                 onClick={() => setOpen('cronjobsuspend')}
               />
             )}
-            {resource && ['cronjobs.batch'].includes(resource) && (
+            {resourceId && ['cronjob.batch'].includes(resourceId) && (
               <Menu.Item
                 label="Resume"
                 onClick={() => setOpen('cronjobresume')}
               />
             )}
-            {resource &&
-              ['certificatesigningrequests.certificates.k8s.io'].includes(
-                resource,
+            {resourceId &&
+              ['certificatesigningrequest.certificates.k8s.io'].includes(
+                resourceId,
               ) && (
                 <Menu.Item
                   label="Approve"
                   onClick={() => setOpen('csrapprove')}
                 />
               )}
-            {resource &&
-              ['certificatesigningrequests.certificates.k8s.io'].includes(
-                resource,
+            {resourceId &&
+              ['certificatesigningrequest.certificates.k8s.io'].includes(
+                resourceId,
               ) && (
                 <Menu.Item label="Deny" onClick={() => setOpen('csrdeny')} />
               )}
-            {resource && ['pods'].includes(resource) && (
+            {resourceId && ['pod'].includes(resourceId) && (
               <Menu.Item label="Evict" onClick={() => setOpen('evict')} />
             )}
-            {resource && ['nodes'].includes(resource) && (
+            {resourceId && ['node'].includes(resourceId) && (
               <Menu.Item label="Cordon" onClick={() => setOpen('cordon')} />
             )}
-            {resource && ['nodes'].includes(resource) && (
+            {resourceId && ['node'].includes(resourceId) && (
               <Menu.Item label="Uncordon" onClick={() => setOpen('uncordon')} />
             )}
-            {resource &&
+            {resourceId &&
               [
-                'daemonsets.apps',
-                'deployments.apps',
-                'jobs.batch',
-                'pods',
-                'statefulsets.apps',
-              ].includes(resource) && (
+                'daemonset.apps',
+                'deployment.apps',
+                'job.batch',
+                'pod',
+                'statefulset.apps',
+              ].includes(resourceId) && (
                 <Menu.Item
                   label="Logs"
                   target="_blank"
-                  url={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: datasource, queries: [{ queryType: 'kubernetes-logs', namespace: namespace, resource: resource, refId: 'A', name: name, container: '' }] }))}`}
+                  url={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: datasource, queries: [{ queryType: 'kubernetes-logs', namespace: namespace, resourceId: resourceId, refId: 'A', name: name, container: '' }] }))}`}
                 />
               )}
             {isAIEnabled && (
@@ -154,7 +154,7 @@ export function Actions(props: Props) {
         <DetailsAction
           settings={props.settings}
           datasource={datasource}
-          resource={resource}
+          resourceId={resourceId}
           namespace={namespace}
           name={name}
           onClose={() => setOpen('')}
@@ -163,7 +163,7 @@ export function Actions(props: Props) {
 
       <ScaleAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'scale'}
@@ -172,7 +172,7 @@ export function Actions(props: Props) {
 
       <RestartAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'restart'}
@@ -181,7 +181,7 @@ export function Actions(props: Props) {
 
       <CreateJobAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'createjob'}
@@ -190,7 +190,7 @@ export function Actions(props: Props) {
 
       <CronJobSuspendAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'cronjobsuspend'}
@@ -199,7 +199,7 @@ export function Actions(props: Props) {
 
       <CronJobResumeAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'cronjobresume'}
@@ -208,7 +208,7 @@ export function Actions(props: Props) {
 
       <CSRApproveAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'csrapprove'}
@@ -217,7 +217,7 @@ export function Actions(props: Props) {
 
       <CSRDenyAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'csrdeny'}
@@ -226,7 +226,7 @@ export function Actions(props: Props) {
 
       <EvictPodAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'evict'}
@@ -235,7 +235,7 @@ export function Actions(props: Props) {
 
       <NodeCordonAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'cordon'}
@@ -244,7 +244,7 @@ export function Actions(props: Props) {
 
       <NodeUncordonAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'uncordon'}
@@ -254,7 +254,7 @@ export function Actions(props: Props) {
       {open === 'ai' && (
         <AIAction
           datasource={datasource}
-          resource={resource}
+          resourceId={resourceId}
           namespace={namespace}
           name={name}
           onClose={() => setOpen('')}
@@ -264,7 +264,7 @@ export function Actions(props: Props) {
       {open === 'edit' && (
         <EditAction
           datasource={datasource}
-          resource={resource}
+          resourceId={resourceId}
           namespace={namespace}
           name={name}
           onClose={() => setOpen('')}
@@ -273,7 +273,7 @@ export function Actions(props: Props) {
 
       <DeleteAction
         datasource={datasource}
-        resource={resource}
+        resourceId={resourceId}
         namespace={namespace}
         name={name}
         isOpen={open === 'delete'}

--- a/src/datasource/components/Kubernetes/CSRApproveAction.tsx
+++ b/src/datasource/components/Kubernetes/CSRApproveAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -32,10 +32,10 @@ export function CSRApproveAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/${resource.resource}/${props.name}/approval?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/${resource.name}/${props.name}/approval?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/CSRDenyAction.tsx
+++ b/src/datasource/components/Kubernetes/CSRDenyAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -32,10 +32,10 @@ export function CSRDenyAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/${resource.resource}/${props.name}/approval?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/${resource.name}/${props.name}/approval?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/CreateJobAction.tsx
+++ b/src/datasource/components/Kubernetes/CreateJobAction.tsx
@@ -14,7 +14,7 @@ import { getResourceManifest } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -41,7 +41,7 @@ export function CreateJobAction(props: Props) {
 
       const manifest = await getResourceManifest(
         props.datasource,
-        props.resource,
+        props.resourceId,
         props.namespace,
         props.name,
       );

--- a/src/datasource/components/Kubernetes/CronJobResumeAction.tsx
+++ b/src/datasource/components/Kubernetes/CronJobResumeAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -28,10 +28,10 @@ export function CronJobResumeAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.name}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/CronJobSuspendAction.tsx
+++ b/src/datasource/components/Kubernetes/CronJobSuspendAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -28,10 +28,10 @@ export function CronJobSuspendAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.name}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/DeleteAction.tsx
+++ b/src/datasource/components/Kubernetes/DeleteAction.tsx
@@ -17,7 +17,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -43,10 +43,10 @@ export function DeleteAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${props.namespace}` : ''}/${resource.resource}/${props.name}`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${props.namespace}` : ''}/${resource.name}/${props.name}`,
         {
           method: 'delete',
           headers: {

--- a/src/datasource/components/Kubernetes/DetailsAction.tsx
+++ b/src/datasource/components/Kubernetes/DetailsAction.tsx
@@ -10,7 +10,6 @@ import {
   Stack,
   Tab,
   TabsBar,
-  Text,
   TextLink,
 } from '@grafana/ui';
 import YAML from 'yaml';
@@ -49,7 +48,10 @@ import {
   V1StatefulSetCondition,
 } from '@kubernetes/client-node';
 
-import { getResourceManifest } from '../../../utils/utils.resource';
+import {
+  getResourceId,
+  getResourceManifest,
+} from '../../../utils/utils.resource';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import {
   DefinitionItem,
@@ -79,7 +81,7 @@ initPluginTranslations('ricoberger-kubernetes-app');
 interface Props {
   settings: DataSourceOptions;
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   onClose: () => void;
@@ -107,7 +109,7 @@ export function DetailsAction(props: Props) {
 
         const manifest = await getResourceManifest(
           props.datasource,
-          props.resource,
+          props.resourceId,
           props.namespace,
           props.name,
         );
@@ -124,7 +126,7 @@ export function DetailsAction(props: Props) {
     };
 
     fetchManifest();
-  }, [props.datasource, props.resource, props.namespace, props.name]);
+  }, [props.datasource, props.resourceId, props.namespace, props.name]);
 
   return (
     <Drawer
@@ -160,12 +162,12 @@ export function DetailsAction(props: Props) {
               }}
             />
             {[
-              'daemonsets.apps',
-              'deployments.apps',
-              'jobs.batch',
-              'nodes',
-              'statefulsets.apps',
-            ].includes(props.resource || '') && (
+              'daemonset.apps',
+              'deployment.apps',
+              'job.batch',
+              'node',
+              'statefulset.apps',
+            ].includes(props.resourceId || '') && (
                 <Tab
                   label="Pods"
                   active={activeTab === 'pods'}
@@ -176,13 +178,13 @@ export function DetailsAction(props: Props) {
                 />
               )}
             {[
-              'daemonsets.apps',
-              'deployments.apps',
-              'jobs.batch',
-              'nodes',
-              'pods',
-              'statefulsets.apps',
-            ].includes(props.resource || '') && (
+              'daemonset.apps',
+              'deployment.apps',
+              'job.batch',
+              'node',
+              'pod',
+              'statefulset.apps',
+            ].includes(props.resourceId || '') && (
                 <Tab
                   label="Top"
                   active={activeTab === 'top'}
@@ -197,17 +199,17 @@ export function DetailsAction(props: Props) {
               props.settings.integrationsMetricsKubeStateMetricsJob &&
               props.settings.integrationsMetricsNodeExporterJob &&
               [
-                'daemonsets.apps',
-                'deployments.apps',
-                'cronjobs.batch',
-                'horizontalpodautoscalers.autoscaling',
-                'jobs.batch',
-                'nodes',
-                'persistentvolumeclaims',
-                'pods',
-                'statefulsets.apps',
-                'verticalpodautoscalers.autoscaling.k8s.io',
-              ].includes(props.resource || '') && (
+                'daemonset.apps',
+                'deployment.apps',
+                'cronjob.batch',
+                'horizontalpodautoscaler.autoscaling',
+                'job.batch',
+                'node',
+                'persistentvolumeclaim',
+                'pod',
+                'statefulset.apps',
+                'verticalpodautoscaler.autoscaling.k8s.io',
+              ].includes(props.resourceId || '') && (
                 <Tab
                   label="Metrics"
                   active={activeTab === 'metrics'}
@@ -246,29 +248,29 @@ export function DetailsAction(props: Props) {
 
           {activeTab === 'metrics' && (
             <>
-              {props.resource === 'daemonsets.apps' && (
+              {props.resourceId === 'daemonset.apps' && (
                 <MetricsDaemonSets {...props} />
               )}
-              {props.resource === 'deployments.apps' && (
+              {props.resourceId === 'deployment.apps' && (
                 <MetricsDeployments {...props} />
               )}
-              {props.resource === 'cronjobs.batch' && (
+              {props.resourceId === 'cronjob.batch' && (
                 <MetricsCronJobs {...props} />
               )}
-              {props.resource === 'horizontalpodautoscalers.autoscaling' && (
+              {props.resourceId === 'horizontalpodautoscaler.autoscaling' && (
                 <MetricsHPAs {...props} />
               )}
-              {props.resource === 'jobs.batch' && <MetricsJobs {...props} />}
-              {props.resource === 'nodes' && <MetricsNodes {...props} />}
-              {props.resource === 'persistentvolumeclaims' && (
+              {props.resourceId === 'job.batch' && <MetricsJobs {...props} />}
+              {props.resourceId === 'node' && <MetricsNodes {...props} />}
+              {props.resourceId === 'persistentvolumeclaim' && (
                 <MetricsPersistentVolumeClaims {...props} />
               )}
-              {props.resource === 'pods' && <MetricsPods {...props} />}
-              {props.resource === 'statefulsets.apps' && (
+              {props.resourceId === 'pod' && <MetricsPods {...props} />}
+              {props.resourceId === 'statefulset.apps' && (
                 <MetricsStatefulSets {...props} />
               )}
-              {props.resource ===
-                'verticalpodautoscalers.autoscaling.k8s.io' && (
+              {props.resourceId ===
+                'verticalpodautoscaler.autoscaling.k8s.io' && (
                   <MetricsVPAs {...props} />
                 )}
             </>
@@ -319,7 +321,7 @@ function DetailsActionEvents(props: Props) {
       {
         refId: 'A',
         queryType: 'kubernetes-resources',
-        resource: 'events',
+        resourceId: 'event',
         namespace: props.namespace || '*',
         parameterName: 'fieldSelector',
         parameterValue: `involvedObject.name=${props.name}`,
@@ -373,7 +375,7 @@ function DetailsActionPods(props: DetailsActionPodsProps) {
       {
         refId: 'A',
         queryType: 'kubernetes-resources',
-        resource: 'pods',
+        resourceId: 'pod',
         namespace: selector ? props.namespace : '*',
         parameterName: selector ? 'labelSelector' : 'fieldSelector',
         parameterValue: selector
@@ -424,11 +426,11 @@ function DetailsActionTop(props: DetailsActionTopProps) {
       {
         refId: 'A',
         queryType: 'kubernetes-resources',
-        resource:
-          props.resource === 'nodes'
-            ? 'nodes.metrics.k8s.io'
-            : 'pods.metrics.k8s.io',
-        namespace: props.resource === 'nodes' ? '*' : props.namespace,
+        resourceId:
+          props.resourceId === 'node'
+            ? 'nodemetrics.metrics.k8s.io'
+            : 'podmetrics.metrics.k8s.io',
+        namespace: props.resourceId === 'node' ? '*' : props.namespace,
         parameterName: selector ? 'labelSelector' : 'fieldSelector',
         parameterValue: selector
           ? selector
@@ -513,12 +515,22 @@ function DetailsActionOverview(props: DetailsActionOverviewProps) {
             </DefinitionItem>
           )}
           {props.manifest.metadata?.ownerReferences && (
-            <DefinitionItem label="Owner">
+            <DefinitionItem label="Owners">
               {props.manifest.metadata?.ownerReferences.map(
                 (owner: V1OwnerReference, index: number) => (
-                  <Text key={index} element="span">
-                    {owner.kind} ({owner.name})
-                  </Text>
+                  <Badge
+                    key={index}
+                    color="darkgrey"
+                    text={
+                      <TextLink
+                        href={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: props.datasource, queries: [{ queryType: 'kubernetes-resources', namespace: props.namespace, resourceId: getResourceId(owner.kind, owner.apiVersion), parameterName: 'fieldSelector', parameterValue: `metadata.name=${owner.name}`, wide: false, refId: 'A' }] }))}`}
+                        color="secondary"
+                        variant="bodySmall"
+                      >
+                        {owner.kind}: {owner.name}
+                      </TextLink>
+                    }
+                  />
                 ),
               )}
             </DefinitionItem>
@@ -533,22 +545,22 @@ function DetailsActionOverview(props: DetailsActionOverviewProps) {
         <Conditions conditions={props.manifest.status.conditions} />
       ) : null}
 
-      {props.manifest && props.resource === 'cronjobs' && (
+      {props.manifest && props.resourceId === 'cronjob.batch' && (
         <CronJob {...props} manifest={props.manifest as V1CronJob} />
       )}
-      {props.manifest && props.resource === 'daemonsets' && (
+      {props.manifest && props.resourceId === 'daemonset.apps' && (
         <DaemonSet {...props} manifest={props.manifest as V1DaemonSet} />
       )}
-      {props.manifest && props.resource === 'deployments' && (
+      {props.manifest && props.resourceId === 'deployment.apps' && (
         <Deployment {...props} manifest={props.manifest as V1Deployment} />
       )}
-      {props.manifest && props.resource === 'jobs' && (
+      {props.manifest && props.resourceId === 'job.batch' && (
         <Job {...props} manifest={props.manifest as V1Job} />
       )}
-      {props.manifest && props.resource === 'pods' && (
+      {props.manifest && props.resourceId === 'pod' && (
         <Pod {...props} manifest={props.manifest as V1Pod} />
       )}
-      {props.manifest && props.resource === 'statefulsets' && (
+      {props.manifest && props.resourceId === 'statefulset.apps' && (
         <StatefulSet {...props} manifest={props.manifest as V1StatefulSet} />
       )}
     </DefinitionLists>
@@ -627,7 +639,7 @@ function Selector(props: {
             color="darkgrey"
             text={
               <TextLink
-                href={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: props.datasource, queries: [{ queryType: 'kubernetes-resources', namespace: props.namespace, resource: 'pods', parameterName: 'labelSelector', parameterValue: `${key}=${props.selector.matchLabels ? props.selector.matchLabels[key] : ''}`, wide: false, refId: 'A' }] }))}`}
+                href={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: props.datasource, queries: [{ queryType: 'kubernetes-resources', namespace: props.namespace, resourceId: 'pod', parameterName: 'labelSelector', parameterValue: `${key}=${props.selector.matchLabels ? props.selector.matchLabels[key] : ''}`, wide: false, refId: 'A' }] }))}`}
                 color="secondary"
                 variant="bodySmall"
               >
@@ -929,7 +941,7 @@ function Pod(props: PodProps) {
         <DefinitionItem label="Node">
           {props.manifest.spec?.nodeName ? (
             <TextLink
-              href={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: props.datasource, queries: [{ queryType: 'kubernetes-resources', namespace: props.namespace, resource: 'nodes', parameterName: 'fieldSelector', parameterValue: `metadata.name=${props.manifest.spec.nodeName}`, wide: false, refId: 'A' }] }))}`}
+              href={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: props.datasource, queries: [{ queryType: 'kubernetes-resources', namespace: props.namespace, resourceId: 'node', parameterName: 'fieldSelector', parameterValue: `metadata.name=${props.manifest.spec.nodeName}`, wide: false, refId: 'A' }] }))}`}
               color="secondary"
               variant="body"
             >

--- a/src/datasource/components/Kubernetes/EditAction.tsx
+++ b/src/datasource/components/Kubernetes/EditAction.tsx
@@ -20,7 +20,7 @@ import { KubernetesManifest } from '../../types/kubernetes';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   onClose: () => void;
@@ -47,7 +47,7 @@ export function EditAction(props: Props) {
         setIsLoading(true);
 
         const manifest = await getResourceManifest(
-          props.resource,
+          props.resourceId,
           props.datasource,
           props.namespace,
           props.name,
@@ -66,7 +66,7 @@ export function EditAction(props: Props) {
     };
 
     fetchManifest();
-  }, [props.datasource, props.resource, props.namespace, props.name]);
+  }, [props.datasource, props.resourceId, props.namespace, props.name]);
 
   /**
    * onSave handles the saving of the edited resource. It creates a JSON patch
@@ -81,10 +81,10 @@ export function EditAction(props: Props) {
       const parsedValue = YAML.parse(value);
       const diff = compare(manifest!, parsedValue);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${props.namespace}` : ''}/${resource.resource}/${props.name}`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${props.namespace}` : ''}/${resource.name}/${props.name}`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/EvictPodAction.tsx
+++ b/src/datasource/components/Kubernetes/EvictPodAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -28,10 +28,10 @@ export function EvictPodAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}/eviction?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.name}/${props.name}/eviction?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'post',
           headers: {

--- a/src/datasource/components/Kubernetes/NodeCordonAction.tsx
+++ b/src/datasource/components/Kubernetes/NodeCordonAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -28,10 +28,10 @@ export function NodeCordonAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/${resource.name}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/NodeUncordonAction.tsx
+++ b/src/datasource/components/Kubernetes/NodeUncordonAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -28,10 +28,10 @@ export function NodeUncordonAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/${resource.name}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/RestartAction.tsx
+++ b/src/datasource/components/Kubernetes/RestartAction.tsx
@@ -13,7 +13,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -37,10 +37,10 @@ export function RestartAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${props.namespace}` : ''}/${resource.resource}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.name}/${props.name}?fieldManager=grafana-kubernetes-plugin`,
         {
           method: 'patch',
           headers: {

--- a/src/datasource/components/Kubernetes/ScaleAction.tsx
+++ b/src/datasource/components/Kubernetes/ScaleAction.tsx
@@ -15,7 +15,7 @@ import { getResource } from '../../../utils/utils.resource';
 
 interface Props {
   datasource?: string;
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   isOpen: boolean;
@@ -40,10 +40,10 @@ export function ScaleAction(props: Props) {
     try {
       setIsLoading(true);
 
-      const resource = await getResource(props.datasource, props.resource);
+      const resource = await getResource(props.datasource, props.resourceId);
 
       const response = await fetch(
-        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.resource}/${props.name}/scale`,
+        `/api/datasources/uid/${props.datasource}/resources/kubernetes/proxy${resource.path}/namespaces/${props.namespace}/${resource.name}/${props.name}/scale`,
         {
           method: 'put',
           headers: {

--- a/src/datasource/components/QueryEditor/FluxResources.tsx
+++ b/src/datasource/components/QueryEditor/FluxResources.tsx
@@ -43,13 +43,13 @@ export function FluxResources({
   }, [datasource]);
 
   /**
-   * Handle "resource" field change.
+   * Handle "resourceId" field change.
    *
-   * When the namespace changes we also immediately run the query, so that the
+   * When the resource id changes we also immediately run the query, so that the
    * user gets instant feedback in the UI.
    */
   const onResourceChange = (option: ComboboxOption<string>) => {
-    onChange({ ...query, resource: option.value });
+    onChange({ ...query, resourceId: option.value });
     onRunQuery();
   };
 
@@ -69,60 +69,60 @@ export function FluxResources({
       <InlineFieldRow>
         <InlineField label="Resource">
           <Combobox<string>
-            value={query.resource}
+            value={query.resourceId}
             createCustomValue={true}
             options={[
               {
                 label: 'Bucket',
-                value: 'buckets.source.toolkit.fluxcd.io',
+                value: 'bucket.source.toolkit.fluxcd.io',
               },
               {
                 label: 'GitRepository',
-                value: 'gitrepositories.source.toolkit.fluxcd.io',
+                value: 'gitrepository.source.toolkit.fluxcd.io',
               },
               {
                 label: 'HelmChart',
-                value: 'helmcharts.source.toolkit.fluxcd.io',
+                value: 'helmchart.source.toolkit.fluxcd.io',
               },
               {
                 label: 'HelmRepository',
-                value: 'helmrepositories.source.toolkit.fluxcd.io',
+                value: 'helmrepository.source.toolkit.fluxcd.io',
               },
               {
                 label: 'OCIRepository',
-                value: 'ocirepositories.source.toolkit.fluxcd.io',
+                value: 'ocirepository.source.toolkit.fluxcd.io',
               },
               {
                 label: 'Kustomization',
-                value: 'kustomizations.kustomize.toolkit.fluxcd.io',
+                value: 'kustomization.kustomize.toolkit.fluxcd.io',
               },
               {
                 label: 'HelmRelease',
-                value: 'helmreleases.helm.toolkit.fluxcd.io',
+                value: 'helmrelease.helm.toolkit.fluxcd.io',
               },
               {
                 label: 'ImagePolicy',
-                value: 'imagepolicies.image.toolkit.fluxcd.io',
+                value: 'imagepolicy.image.toolkit.fluxcd.io',
               },
               {
                 label: 'ImageRepository',
-                value: 'imagerepositories.image.toolkit.fluxcd.io',
+                value: 'imagerepository.image.toolkit.fluxcd.io',
               },
               {
                 label: 'ImageUpdateAutomation',
-                value: 'imageupdateautomations.image.toolkit.fluxcd.io',
+                value: 'imageupdateautomation.image.toolkit.fluxcd.io',
               },
               {
                 label: 'Alert',
-                value: 'alerts.notification.toolkit.fluxcd.io',
+                value: 'alert.notification.toolkit.fluxcd.io',
               },
               {
                 label: 'Provider',
-                value: 'providers.notification.toolkit.fluxcd.io',
+                value: 'provider.notification.toolkit.fluxcd.io',
               },
               {
                 label: 'Receiver',
-                value: 'receivers.notification.toolkit.fluxcd.io',
+                value: 'receiver.notification.toolkit.fluxcd.io',
               },
             ]}
             onChange={onResourceChange}

--- a/src/datasource/components/QueryEditor/KubernetesLogs.tsx
+++ b/src/datasource/components/QueryEditor/KubernetesLogs.tsx
@@ -47,8 +47,8 @@ export function KubernetesLogs({
 
   /**
    * Fetch available names from the datasource, which can then be used as
-   * options in the "name" field. The names are only fetched a "namespace" is
-   * selected.
+   * options in the "name" field. The names are only fetched when a "namespace"
+   * is selected.
    */
   useEffect(() => {
     const fetchNames = async () => {
@@ -56,7 +56,7 @@ export function KubernetesLogs({
         refId: 'kubernetes-resources',
         queryType: 'kubernetes-resources',
         variableField: 'Name',
-        resource: query.resource,
+        resourceId: query.resourceId,
         namespace: query.namespace,
       });
 
@@ -70,11 +70,11 @@ export function KubernetesLogs({
     if (query.namespace) {
       fetchNames();
     }
-  }, [datasource, query.resource, query.namespace]);
+  }, [datasource, query.resourceId, query.namespace]);
 
   /**
    * Fetch available containers from the datasource, which can then be used as
-   * options in the "container" field. The containers are only fetched a
+   * options in the "container" field. The containers are only fetched when a
    * "namespace" or "name" is selected.
    */
   useEffect(() => {
@@ -82,7 +82,7 @@ export function KubernetesLogs({
       const result = await datasource.metricFindQuery({
         refId: 'kubernetes-containers',
         queryType: 'kubernetes-containers',
-        resource: query.resource,
+        resourceId: query.resourceId,
         namespace: query.namespace,
         name: query.name,
       });
@@ -102,18 +102,19 @@ export function KubernetesLogs({
       fetchContainers();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasource, query.resource, query.namespace, query.name]);
+  }, [datasource, query.resourceId, query.namespace, query.name]);
 
   /**
-   * Handle "resource" field change. If the "resource" changes we also clear the
-   * "name" and "container" fields, because the newly selected resource might
-   * not have the same names and containers as the previously selected one.
+   * Handle "resourceId" field change. If the "resourceId" changes we also clear
+   * the "name" and "container" fields, because the newly selected resource
+   * might not have the same names and containers as the previously selected
+   * one.
    *
-   * When the namespace changes we also immediately run the query, so that the
+   * When the resource id changes we also immediately run the query, so that the
    * user gets instant feedback in the UI.
    */
   const onResourceChange = (option: ComboboxOption<string>) => {
-    onChange({ ...query, resource: option.value, name: '', container: '' });
+    onChange({ ...query, resourceId: option.value, name: '', container: '' });
     onRunQuery();
   };
 
@@ -166,14 +167,14 @@ export function KubernetesLogs({
       <InlineFieldRow>
         <InlineField label="Resource">
           <Combobox<string>
-            value={query.resource}
+            value={query.resourceId}
             createCustomValue={true}
             options={[
-              { value: 'daemonsets.apps', label: 'DaemonSet' },
-              { value: 'deployments.apps', label: 'Deployment' },
-              { value: 'pods', label: 'Pod' },
-              { value: 'jobs.batch', label: 'Job' },
-              { value: 'statefulsets.apps', label: 'StatefulSet' },
+              { value: 'daemonset.apps', label: 'DaemonSet' },
+              { value: 'deployment.apps', label: 'Deployment' },
+              { value: 'pod', label: 'Pod' },
+              { value: 'job.batch', label: 'Job' },
+              { value: 'statefulset.apps', label: 'StatefulSet' },
             ]}
             onChange={onResourceChange}
           />

--- a/src/datasource/components/QueryEditor/KubernetesResources.tsx
+++ b/src/datasource/components/QueryEditor/KubernetesResources.tsx
@@ -22,28 +22,28 @@ export function KubernetesResources({
   onChange,
   onRunQuery,
 }: Props) {
-  const [resources, setResources] = useState<ComboboxOption[]>([]);
+  const [resourceIds, setResourceIds] = useState<ComboboxOption[]>([]);
   const [namespaces, setNamespaces] = useState<ComboboxOption[]>([]);
 
   /**
-   * Fetch available resource kinds from the datasource, which can then be used
-   * as options in the "resource" field.
+   * Fetch available resource ids from the datasource, which can then be used
+   * as options in the "resourceId" field.
    */
   useEffect(() => {
-    const fetchResources = async () => {
+    const fetchResourceIds = async () => {
       const result = await datasource.metricFindQuery({
         refId: 'kubernetes-resourceids',
         queryType: 'kubernetes-resourceids',
       });
 
-      setResources(
+      setResourceIds(
         result.map((value) => {
           return { value: value.value as string, label: value.text };
         }),
       );
     };
 
-    fetchResources();
+    fetchResourceIds();
   }, [datasource]);
 
   /**
@@ -68,13 +68,13 @@ export function KubernetesResources({
   }, [datasource]);
 
   /**
-   * Handle "resource" field change.
+   * Handle "resourceId" field change.
    *
-   * When the namespace changes we also immediately run the query, so that the
+   * When the resource id changes we also immediately run the query, so that the
    * user gets instant feedback in the UI.
    */
-  const onResourceChange = (option: ComboboxOption<string>) => {
-    onChange({ ...query, resource: option.value });
+  const onResourceIdChange = (option: ComboboxOption<string>) => {
+    onChange({ ...query, resourceId: option.value });
     onRunQuery();
   };
 
@@ -128,10 +128,10 @@ export function KubernetesResources({
       <InlineFieldRow>
         <InlineField label="Resource">
           <Combobox<string>
-            value={query.resource}
+            value={query.resourceId}
             createCustomValue={true}
-            options={resources}
-            onChange={onResourceChange}
+            options={resourceIds}
+            onChange={onResourceIdChange}
           />
         </InlineField>
         <InlineField label="Namespace">

--- a/src/datasource/components/VariableQueryEditor/KubernetesContainers.tsx
+++ b/src/datasource/components/VariableQueryEditor/KubernetesContainers.tsx
@@ -16,30 +16,30 @@ interface Props
   extends QueryEditorProps<DataSource, any, DataSourceOptions, Query> { }
 
 export function KubernetesContainers(props: Props) {
-  const [resources, setResources] = useState<ComboboxOption[]>([]);
+  const [resourceIds, setResourceIds] = useState<ComboboxOption[]>([]);
   const [namespaces, setNamespaces] = useState<ComboboxOption[]>([]);
   const [names, setNames] = useState<ComboboxOption[]>([]);
   const { datasource, query, onChange } = props;
 
   /**
-   * Fetch available resource kinds from the datasource, which can then be used
-   * as options in the "resource" field.
+   * Fetch available resource ids from the datasource, which can then be used
+   * as options in the "resourceId" field.
    */
   useEffect(() => {
-    const fetchResources = async () => {
+    const fetchResourceIds = async () => {
       const result = await datasource.metricFindQuery({
         refId: 'kubernetes-resourceids',
         queryType: 'kubernetes-resourceids',
       });
 
-      setResources(
+      setResourceIds(
         result.map((value) => {
           return { value: value.value as string, label: value.text };
         }),
       );
     };
 
-    fetchResources();
+    fetchResourceIds();
   }, [datasource]);
 
   /**
@@ -73,7 +73,7 @@ export function KubernetesContainers(props: Props) {
         refId: 'kubernetes-resources',
         queryType: 'kubernetes-resources',
         variableField: 'Name',
-        resource: query.resource,
+        resourceId: query.resourceId,
         namespace: query.namespace,
       });
 
@@ -85,13 +85,13 @@ export function KubernetesContainers(props: Props) {
     };
 
     fetchNames();
-  }, [datasource, query.resource, query.namespace]);
+  }, [datasource, query.resourceId, query.namespace]);
 
   /**
-   * Handle "resource" field change.
+   * Handle "resourceId" field change.
    */
   const onResourceChange = (option: ComboboxOption<string>) => {
-    onChange({ ...query, resource: option.value });
+    onChange({ ...query, resourceId: option.value });
   };
 
   /**
@@ -113,9 +113,9 @@ export function KubernetesContainers(props: Props) {
       <InlineFieldRow>
         <InlineField label="Resource">
           <Combobox<string>
-            value={query.resource}
+            value={query.resourceId}
             createCustomValue={true}
-            options={resources}
+            options={resourceIds}
             onChange={onResourceChange}
           />
         </InlineField>

--- a/src/datasource/components/VariableQueryEditor/KubernetesResources.tsx
+++ b/src/datasource/components/VariableQueryEditor/KubernetesResources.tsx
@@ -17,29 +17,29 @@ interface Props
   extends QueryEditorProps<DataSource, any, DataSourceOptions, Query> { }
 
 export function KubernetesResources(props: Props) {
-  const [resources, setResources] = useState<ComboboxOption[]>([]);
+  const [resourceIds, setResourceIds] = useState<ComboboxOption[]>([]);
   const [namespaces, setNamespaces] = useState<ComboboxOption[]>([]);
   const { datasource, query, onChange } = props;
 
   /**
-   * Fetch available resource kinds from the datasource, which can then be used
-   * as options in the "resource" field.
+   * Fetch available resource ids from the datasource, which can then be used
+   * as options in the "resourceId" field.
    */
   useEffect(() => {
-    const fetchResources = async () => {
+    const fetchResourceIds = async () => {
       const result = await datasource.metricFindQuery({
         refId: 'kubernetes-resourceids',
         queryType: 'kubernetes-resourceids',
       });
 
-      setResources(
+      setResourceIds(
         result.map((value) => {
           return { value: value.value as string, label: value.text };
         }),
       );
     };
 
-    fetchResources();
+    fetchResourceIds();
   }, [datasource]);
 
   /**
@@ -64,10 +64,10 @@ export function KubernetesResources(props: Props) {
   }, [datasource]);
 
   /**
-   * Handle "resource" field change.
+   * Handle "resourceId" field change.
    */
   const onResourceChange = (option: ComboboxOption<string>) => {
-    onChange({ ...query, resource: option.value });
+    onChange({ ...query, resourceId: option.value });
   };
 
   /**
@@ -89,9 +89,9 @@ export function KubernetesResources(props: Props) {
       <InlineFieldRow>
         <InlineField label="Resource">
           <Combobox<string>
-            value={query.resource}
+            value={query.resourceId}
             createCustomValue={true}
-            options={resources}
+            options={resourceIds}
             onChange={onResourceChange}
           />
         </InlineField>

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -45,7 +45,7 @@ export class DataSource extends DataSourceWithBackend<
     return {
       ...query,
       variableField: getTemplateSrv().replace(query.variableField, scopedVars),
-      resource: getTemplateSrv().replace(query.resource, scopedVars),
+      resourceId: getTemplateSrv().replace(query.resourceId, scopedVars),
       namespace: getTemplateSrv().replace(query.namespace, scopedVars),
       parameterName: getTemplateSrv().replace(query.parameterName, scopedVars),
       parameterValue: getTemplateSrv().replace(
@@ -214,7 +214,7 @@ export class DataSource extends DataSourceWithBackend<
      */
     if (
       query.queryType === 'kubernetes-containers' &&
-      (!query.resource || !query.namespace || !query.name)
+      (!query.resourceId || !query.namespace || !query.name)
     ) {
       return false;
     }
@@ -225,7 +225,7 @@ export class DataSource extends DataSourceWithBackend<
      */
     if (
       query.queryType === 'kubernetes-resources' &&
-      (!query.resource || !query.namespace)
+      (!query.resourceId || !query.namespace)
     ) {
       return false;
     }
@@ -236,7 +236,7 @@ export class DataSource extends DataSourceWithBackend<
      */
     if (
       query.queryType === 'kubernetes-logs' &&
-      (!query.resource || !query.namespace || !query.name || !query.container)
+      (!query.resourceId || !query.namespace || !query.name || !query.container)
     ) {
       return false;
     }
@@ -266,7 +266,7 @@ export class DataSource extends DataSourceWithBackend<
      */
     if (
       query.queryType === 'flux-resources' &&
-      (!query.resource || !query.namespace)
+      (!query.resourceId || !query.namespace)
     ) {
       return false;
     }

--- a/src/datasource/types/kubernetes.ts
+++ b/src/datasource/types/kubernetes.ts
@@ -5,8 +5,10 @@ import { KubernetesObject } from '@kubernetes/client-node';
  * fields to identify and work with this resource.
  */
 export interface Resource {
+  id: string;
   kind: string;
-  resource: string;
+  apiVersion: string;
+  name: string;
   path: string;
   namespaced: boolean;
 }

--- a/src/datasource/types/query.ts
+++ b/src/datasource/types/query.ts
@@ -7,7 +7,7 @@ import { DataQuery } from '@grafana/schema';
  */
 export const DEFAULT_QUERY: Partial<Query> = {
   queryType: 'kubernetes-resources',
-  resource: 'pods',
+  resourceId: 'pod',
   namespace: 'default',
   wide: false,
 };
@@ -20,12 +20,12 @@ export const DEFAULT_QUERIES: Record<QueryType, Partial<Query>> = {
   'kubernetes-resourceids': {},
   'kubernetes-namespaces': {},
   'kubernetes-containers': {
-    resource: 'pods',
+    resourceId: 'pods',
     namespace: 'default',
     name: '',
   },
   'kubernetes-resources': {
-    resource: 'pods',
+    resourceId: 'pod',
     namespace: 'default',
     parameterName: '',
     parameterValue: '',
@@ -39,7 +39,7 @@ export const DEFAULT_QUERIES: Record<QueryType, Partial<Query>> = {
     variableField: 'Name',
   },
   'kubernetes-logs': {
-    resource: 'pods',
+    resourceId: 'pod',
     namespace: 'default',
     name: '',
     container: '',
@@ -53,7 +53,7 @@ export const DEFAULT_QUERIES: Record<QueryType, Partial<Query>> = {
     name: '',
   },
   'flux-resources': {
-    resource: 'kustomizations.kustomize.toolkit.fluxcd.io',
+    resourceId: 'kustomization.kustomize.toolkit.fluxcd.io',
     namespace: 'default',
   },
 };
@@ -97,7 +97,7 @@ export interface QueryModelVariable {
 }
 
 export interface QueryModelKubernetesResources {
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   parameterName?: string;
   parameterValue?: string;
@@ -105,13 +105,13 @@ export interface QueryModelKubernetesResources {
 }
 
 export interface QueryModelKubernetesContainers {
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
 }
 
 export interface QueryModelKubernetesLogs {
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
   name?: string;
   container?: string;
@@ -128,6 +128,6 @@ export interface QueryModelHelmReleaseHistory {
 }
 
 export interface QueryModelFluxResources {
-  resource?: string;
+  resourceId?: string;
   namespace?: string;
 }

--- a/src/pages/Flux/fluxScene.ts
+++ b/src/pages/Flux/fluxScene.ts
@@ -24,12 +24,12 @@ export function fluxScene() {
     pluginId: datasourcePluginJson.id,
   });
 
-  const resourceVariable = new CustomVariable({
-    name: 'resource',
+  const resourceIdVariable = new CustomVariable({
+    name: 'resourceId',
     label: 'Resource',
     query:
-      'Bucket : buckets.source.toolkit.fluxcd.io, GitRepository : gitrepositories.source.toolkit.fluxcd.io, HelmChart : helmcharts.source.toolkit.fluxcd.io, HelmRepository : helmrepositories.source.toolkit.fluxcd.io, OCIRepository : ocirepositories.source.toolkit.fluxcd.io, Kustomization : kustomizations.kustomize.toolkit.fluxcd.io, HelmRelease : helmreleases.helm.toolkit.fluxcd.io, ImagePolicy : imagepolicies.image.toolkit.fluxcd.io, ImageRepository : imagerepositories.image.toolkit.fluxcd.io, ImageUpdateAutomation : imageupdateautomations.image.toolkit.fluxcd.io, Alert : alerts.notification.toolkit.fluxcd.io, Provider : providers.notification.toolkit.fluxcd.io, Receiver : receivers.notification.toolkit.fluxcd.io,',
-    value: DEFAULT_QUERIES['flux-resources'].resource,
+      'Bucket : bucket.source.toolkit.fluxcd.io, GitRepository : gitrepository.source.toolkit.fluxcd.io, HelmChart : helmchart.source.toolkit.fluxcd.io, HelmRepository : helmrepository.source.toolkit.fluxcd.io, OCIRepository : ocirepository.source.toolkit.fluxcd.io, Kustomization : kustomization.kustomize.toolkit.fluxcd.io, HelmRelease : helmrelease.helm.toolkit.fluxcd.io, ImagePolicy : imagepolicy.image.toolkit.fluxcd.io, ImageRepository : imagerepository.imagerepositories.image.toolkit.fluxcd.io, ImageUpdateAutomation : imageupdateautomation.image.toolkit.fluxcd.io, Alert : alert.notification.toolkit.fluxcd.io, Provider : provider.notification.toolkit.fluxcd.io, Receiver : receiver.notification.toolkit.fluxcd.io,',
+    value: DEFAULT_QUERIES['flux-resources'].resourceId,
   });
 
   const namespaceVariable = new QueryVariable({
@@ -56,7 +56,7 @@ export function fluxScene() {
       {
         refId: 'A',
         queryType: 'flux-resources',
-        resource: '${resource}',
+        resourceId: '${resourceId}',
         namespace: '${namespace}',
       },
     ],
@@ -64,7 +64,7 @@ export function fluxScene() {
 
   return new EmbeddedScene({
     $variables: new SceneVariableSet({
-      variables: [datasourceVariable, resourceVariable, namespaceVariable],
+      variables: [datasourceVariable, resourceIdVariable, namespaceVariable],
     }),
     $data: queryRunner,
     body: new SceneFlexLayout({

--- a/src/pages/Resources/resourcesScene.ts
+++ b/src/pages/Resources/resourcesScene.ts
@@ -23,8 +23,8 @@ export function resourcesScene() {
     pluginId: datasourcePluginJson.id,
   });
 
-  const resourceVariable = new QueryVariable({
-    name: 'resource',
+  const resourceIdVariable = new QueryVariable({
+    name: 'resourceId',
     label: 'Resource',
     datasource: {
       type: datasourcePluginJson.id,
@@ -35,7 +35,7 @@ export function resourcesScene() {
       queryType: 'kubernetes-resourceids',
     },
     sort: VariableSort.alphabeticalCaseInsensitiveAsc,
-    value: DEFAULT_QUERIES['kubernetes-resources'].resource,
+    value: DEFAULT_QUERIES['kubernetes-resources'].resourceId,
   });
 
   const namespaceVariable = new QueryVariable({
@@ -62,7 +62,7 @@ export function resourcesScene() {
       {
         refId: 'A',
         queryType: 'kubernetes-resources',
-        resource: '${resource}',
+        resourceId: '${resourceId}',
         namespace: '${namespace}',
       },
     ],
@@ -70,7 +70,7 @@ export function resourcesScene() {
 
   return new EmbeddedScene({
     $variables: new SceneVariableSet({
-      variables: [datasourceVariable, resourceVariable, namespaceVariable],
+      variables: [datasourceVariable, resourceIdVariable, namespaceVariable],
     }),
     $data: queryRunner,
     body: new SceneFlexLayout({

--- a/src/utils/utils.resource.ts
+++ b/src/utils/utils.resource.ts
@@ -2,16 +2,35 @@ import { EventsV1EventList } from '@kubernetes/client-node';
 
 import { KubernetesManifest, Resource } from '../datasource/types/kubernetes';
 
+/**
+ * Get the internal resource id for the resource kind and apiVersion
+ * (groupVersion). The id is in the format: kind.group (lowercase). This allows
+ * us to uniquely identify resources based on their kind and apiVersion. The
+ * version is not included in the id as it can be changed (e.g. when a CRD is
+ * upgraded) and could break existing references in dashboards.
+ *
+ * The backend implementation of generating the id, could be found in the
+ * "resources.go" file.
+ */
+export const getResourceId = (kind: string, apiVersion: string): string => {
+  let id = kind;
+  const groupVersion = apiVersion.split('/');
+  if (groupVersion.length === 2) {
+    id = `${kind}.${groupVersion[0]}`;
+  }
+  return id.toLowerCase();
+};
+
 export const getResource = async (
   datasource: string | undefined,
-  resource: string | undefined,
+  resourceId: string | undefined,
 ): Promise<Resource> => {
-  if (!datasource || !resource) {
+  if (!datasource || !resourceId) {
     throw new Error();
   }
 
   const response = await fetch(
-    `/api/datasources/uid/${datasource}/resources/kubernetes/resource/${resource}`,
+    `/api/datasources/uid/${datasource}/resources/kubernetes/resource/${resourceId}`,
   );
   if (!response.ok) {
     throw new Error(await response.text());
@@ -33,7 +52,7 @@ export const getResourceManifest = async (
   const resource = await getResource(datasource, resourceId);
 
   const response = await fetch(
-    `/api/datasources/uid/${datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${namespace}` : ''}/${resource.resource}/${name}`,
+    `/api/datasources/uid/${datasource}/resources/kubernetes/proxy${resource.path}${resource.namespaced ? `/namespaces/${namespace}` : ''}/${resource.name}/${name}`,
     {
       method: 'get',
       headers: {


### PR DESCRIPTION
- Use kind and group for resource id, instead of the resource name and
  group, so that the id can be generated using the kind and apiVersion
  fields of a Kubernetes resource manifest.
- Update name of `resource` variable to `resourceId` in frontend code,
  to make it more clear, when we are using the id and when the resource.
- Link owner references in resource details to the corresponding
  resource explore query.
