### PR TITLE
Replace Explore Links with Drawer

### DIFF
--- a/src/datasource/components/shared/details/Resources.tsx
+++ b/src/datasource/components/shared/details/Resources.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Drawer } from '@grafana/ui';
 import {
   EmbeddedScene,
   PanelBuilders,
@@ -10,12 +11,26 @@ import {
 import datasourcePluginJson from '../../../plugin.json';
 
 interface Props {
+  title: string;
   datasource?: string;
+  resourceId?: string;
   namespace?: string;
-  name?: string;
+  parameterName?: string;
+  parameterValue?: string;
+  onClose: () => void;
 }
 
-export function Events({ datasource, namespace, name }: Props) {
+export function Resources({
+  title,
+  datasource,
+  resourceId,
+  namespace,
+  parameterName,
+  parameterValue,
+  onClose,
+}: Props) {
+  console.log(datasource, resourceId, namespace, parameterName, parameterValue);
+
   const queryRunner = new SceneQueryRunner({
     datasource: {
       type: datasourcePluginJson.id,
@@ -25,10 +40,10 @@ export function Events({ datasource, namespace, name }: Props) {
       {
         refId: 'A',
         queryType: 'kubernetes-resources',
-        resourceId: 'events',
+        resourceId: resourceId,
         namespace: namespace || '*',
-        parameterName: 'fieldSelector',
-        parameterValue: `involvedObject.name=${name}`,
+        parameterName: parameterName || '',
+        parameterValue: parameterValue || '',
       },
     ],
   });
@@ -38,11 +53,15 @@ export function Events({ datasource, namespace, name }: Props) {
     body: new SceneFlexLayout({
       children: [
         new SceneFlexItem({
-          body: PanelBuilders.table().setTitle('Events').build(),
+          body: PanelBuilders.table().setTitle(title).build(),
         }),
       ],
     }),
   });
 
-  return <scene.Component model={scene} />;
+  return (
+    <Drawer title={title} scrollableContent={false} onClose={() => onClose()}>
+      <scene.Component model={scene} />
+    </Drawer>
+  );
 }

--- a/src/datasource/components/shared/details/Selector.tsx
+++ b/src/datasource/components/shared/details/Selector.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { V1LabelSelector } from '@kubernetes/client-node';
-import { Badge, TextLink } from '@grafana/ui';
+import { Badge } from '@grafana/ui';
 
 import { DefinitionItem } from '../../shared/definitionlist/DefinitionList';
+import { Resources } from './Resources';
 
 interface Props {
   datasource?: string;
@@ -11,24 +12,37 @@ interface Props {
 }
 
 export function Selector({ datasource, namespace, selector }: Props) {
+  const [selectedSelector, setSelectedSelector] = useState<string>('');
+
   return (
-    <DefinitionItem label="Selector">
-      {selector.matchLabels &&
-        Object.keys(selector.matchLabels).map((key) => (
-          <Badge
-            key={key}
-            color="darkgrey"
-            text={
-              <TextLink
-                href={`/explore?left=${encodeURIComponent(JSON.stringify({ datasource: datasource, queries: [{ queryType: 'kubernetes-resources', namespace: namespace, resourceId: 'pod', parameterName: 'labelSelector', parameterValue: `${key}=${selector.matchLabels ? selector.matchLabels[key] : ''}`, wide: false, refId: 'A' }] }))}`}
-                color="secondary"
-                variant="bodySmall"
-              >
-                {key}={selector.matchLabels ? selector.matchLabels[key] : ''}
-              </TextLink>
-            }
+    <>
+      <DefinitionItem label="Selector">
+        {selector.matchLabels &&
+          Object.keys(selector.matchLabels).map((key) => (
+            <Badge
+              key={key}
+              color="blue"
+              onClick={() =>
+                setSelectedSelector(
+                  `${key}=${selector.matchLabels ? selector.matchLabels[key] : ''}`,
+                )
+              }
+              text={`${key}=${selector.matchLabels ? selector.matchLabels[key] : ''}`}
+            />
+          ))}
+
+        {selectedSelector && (
+          <Resources
+            title="Pods"
+            datasource={datasource}
+            resourceId="pod"
+            namespace={namespace}
+            parameterName="labelSelector"
+            parameterValue={selectedSelector}
+            onClose={() => setSelectedSelector('')}
           />
-        ))}
-    </DefinitionItem>
+        )}
+      </DefinitionItem>
+    </>
   );
 }

--- a/src/pages/helm/HelmScene.ts
+++ b/src/pages/helm/HelmScene.ts
@@ -47,7 +47,6 @@ export function HelmScene() {
       {
         refId: 'A',
         queryType: 'helm-releases',
-        resource: '${resource}',
         namespace: '${namespace}',
       },
     ],


### PR DESCRIPTION
Instead of linking to the explore view, we now show the resources,
linked in the details, within a drawer. This has the advantage that the
user does not lose context of the current view and that we can render
the actions for the opened resource directly in the drawer.

This commit also fixes the query for events and Helm releases.
