### PR TITLE
Add `kubectl-grafana` Plugin

### DIFF
--- a/.github/workflows/kubectl-grafana.yml
+++ b/.github/workflows/kubectl-grafana.yml
@@ -1,0 +1,55 @@
+---
+name: Continuous Delivery
+
+on:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  kubectl-grafana:
+    name: kubectl-grafana
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Install Dependencies
+        run: |
+          go mod download
+
+      - name: Build
+        run: |
+          go tool mage -v buildAllKubectl
+
+          cd ./dist/kubectl-grafana
+          tar -czf ../../kubectl-grafana.tar.gz *
+
+      - name: Upload Artifact (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: kubectl-grafana.tar.gz
+          path: kubectl-grafana.tar.gz
+          if-no-files-found: error
+
+      - name: Upload Artifact (Release)
+        uses: shogo82148/actions-upload-release-asset@v1
+        if:
+          ${{ github.event_name == 'release' && github.event.action ==
+          'published' }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: kubectl-grafana.tar.gz

--- a/Magefile.go
+++ b/Magefile.go
@@ -4,9 +4,129 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"time"
+
 	// mage:import
 	build "github.com/grafana/grafana-plugin-sdk-go/build"
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
 )
 
 // Default configures the default target.
 var Default = build.BuildAll
+
+// Config holds the setup variables required for a build
+type Config struct {
+	OS   string // GOOS
+	Arch string // GOOS
+}
+
+// BeforeBuildCallback hooks into the build process
+type BeforeBuildCallback func(cfg Config) (Config, error)
+
+func newBuildConfig(os string, arch string) Config {
+	return Config{
+		OS:   os,
+		Arch: arch,
+	}
+}
+
+func getVersion() string {
+	packageJson := make(map[string]any)
+
+	packageJsonFile, err := os.Open("package.json")
+	if err != nil {
+		return ""
+	}
+
+	jsonParser := json.NewDecoder(packageJsonFile)
+	if err = jsonParser.Decode(&packageJson); err != nil {
+		return ""
+	}
+
+	return packageJson["version"].(string)
+}
+
+func getGitInfo(args ...string) string {
+	out, err := exec.CommandContext(context.Background(), "git", args...).Output()
+	if err != nil {
+		return ""
+	}
+
+	return string(out)
+}
+
+func buildBackend(cfg Config) error {
+	env := map[string]string{
+		"GOARCH":      cfg.Arch,
+		"GOOS":        cfg.OS,
+		"CGO_ENABLED": "0",
+	}
+
+	version := getVersion()
+	revision := getGitInfo("rev-parse", "HEAD")
+	branch := getGitInfo("rev-parse", "--abbrev-ref", "HEAD")
+	buildDate := time.Now().Format(time.RFC3339)
+
+	buildUser := ""
+	user, _ := user.Current()
+	if user != nil {
+		buildUser = user.Username
+	}
+
+	args := []string{
+		"build",
+		"-o",
+		filepath.Join("dist", "kubectl-grafana", fmt.Sprintf("kubectl-grafana-%s-%s", cfg.OS, cfg.Arch)),
+		"-ldflags",
+		fmt.Sprintf(`-w -s -extldflags "-static" -X github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/version.Version=%s -X github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/version.Revision=%s -X github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/version.Branch=%s -X github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/version.BuildUser=%s -X github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/version.BuildDate=%s`, version, revision, branch, buildUser, buildDate),
+		"./cmd/kubectl-grafana",
+	}
+
+	return sh.RunWithV(env, "go", args...)
+}
+
+// BuildKubectl is a namespace.
+type BuildKubectl mg.Namespace
+
+// Linux builds the kubectl plugin for Linux.
+func (BuildKubectl) Linux() error {
+	return buildBackend(newBuildConfig("linux", "amd64"))
+}
+
+// LinuxARM builds the kubectl plugin for Linux on ARM.
+func (BuildKubectl) LinuxARM() error {
+	return buildBackend(newBuildConfig("linux", "arm"))
+}
+
+// LinuxARM64 builds the kubectl plugin for Linux on ARM64.
+func (BuildKubectl) LinuxARM64() error {
+	return buildBackend(newBuildConfig("linux", "arm64"))
+}
+
+// Windows builds the kubectl plugin for Windows.
+func (BuildKubectl) Windows() error {
+	return buildBackend(newBuildConfig("windows", "amd64"))
+}
+
+// Darwin builds the kubectl plugin for OSX on AMD64.
+func (BuildKubectl) Darwin() error {
+	return buildBackend(newBuildConfig("darwin", "amd64"))
+}
+
+// DarwinARM64 builds the kubectl plugin for OSX on ARM (M1/M2).
+func (BuildKubectl) DarwinARM64() error {
+	return buildBackend(newBuildConfig("darwin", "arm64"))
+}
+
+func BuildAllKubectl() {
+	b := BuildKubectl{}
+	mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM)
+}

--- a/cmd/kubectl-grafana/kubeconfig/kubeconfig.go
+++ b/cmd/kubectl-grafana/kubeconfig/kubeconfig.go
@@ -1,0 +1,116 @@
+package kubeconfig
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/utils"
+
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	"sigs.k8s.io/yaml"
+)
+
+type Cmd struct {
+	Url        string `default:"" help:"Url of the Grafana instance, e.g. \"https://grafana.ricoberger.de/\"."`
+	Datasource string `default:"kubernetes" help:"Uid of the Kubernetes datasource."`
+	Kubeconfig string `default:"$HOME/.kube/config" help:"The file to which the Kubeconfig should be written."`
+}
+
+func (r *Cmd) Run() error {
+	// Validate that all required command-line flags are set. If a flag is
+	// missing return an error.
+	if r.Url == "" {
+		return fmt.Errorf("url is required")
+	}
+	if r.Datasource == "" {
+		return fmt.Errorf("datasource is required")
+	}
+	if r.Kubeconfig == "" {
+		return fmt.Errorf("kubeconfig is required")
+	}
+
+	// Create the url, which can be used to download the Kubeconfig from the
+	// Grafana instance. It is important to set the "type=exec" and
+	// "redirect=http://localhost:11716" query parameters, so that Grafana
+	// redirects the Kubeconfig to our local HTTP server.
+	kubeconfigUrl := fmt.Sprintf("%sapi/datasources/uid/%s/resources/kubernetes/kubeconfig?type=exec&redirect=%s", r.Url, r.Datasource, url.QueryEscape("http://localhost:11716"))
+	kubeconfigFile := utils.ExpandEnv(r.Kubeconfig)
+	doneChannel := make(chan error)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// When the function is done, send the error (if any) to the
+		// "doneChannel", so that the main function can exit.
+		var err error
+
+		defer func() {
+			doneChannel <- err
+		}()
+
+		// Extrace the "kubeconfig" query parameter from the redirect request
+		// and return an error if it is missing.
+		kubeconfigParam := r.URL.Query().Get("kubeconfig")
+		if kubeconfigParam == "" {
+			err = fmt.Errorf("kubeconfig parameter is missing in redirect")
+			return
+		}
+
+		// Create a temporary file, which contains the Kubeconfig downloaded
+		// from Grafana in YAML format.
+		tmpKubeconfig, err := yaml.JSONToYAML([]byte(kubeconfigParam))
+		if err != nil {
+			return
+		}
+
+		f, err := os.CreateTemp("", "tmp-kubeconfig.yaml")
+		if err != nil {
+			return
+		}
+		defer os.Remove(f.Name())
+
+		if _, err := f.Write(tmpKubeconfig); err != nil {
+			return
+		}
+		defer f.Close()
+
+		// Load the temporary Kubeconfig file and merge it with the existing
+		// Kubeconfig file (if it exists). The merged Kubeconfig is then
+		// written back to the original Kubeconfig file.
+		loadingRules := clientcmd.ClientConfigLoadingRules{
+			Precedence: []string{f.Name(), kubeconfigFile},
+		}
+		mergedConfig, err := loadingRules.Load()
+		if err != nil {
+			return
+		}
+
+		json, err := k8sruntime.Encode(clientcmdlatest.Codec, mergedConfig)
+		if err != nil {
+			return
+		}
+		output, err := yaml.JSONToYAML(json)
+		if err != nil {
+			return
+		}
+
+		if err := os.WriteFile(kubeconfigFile, output, 0600); err != nil {
+			return
+		}
+
+		fmt.Fprintf(w, "Kubeconfig was saved to %s", kubeconfigFile)
+	})
+
+	// Start the HTTP server, which listens for the redirect from Grafana on
+	// port 11716.
+	// #nosec G114
+	go http.ListenAndServe(":11716", nil)
+
+	// Open the url in the users default browser and wait until Grafana
+	// redirects the user to our local HTTP server.
+	utils.OpenUrl(kubeconfigUrl)
+	err := <-doneChannel
+	return err
+}

--- a/cmd/kubectl-grafana/main.go
+++ b/cmd/kubectl-grafana/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/kubeconfig"
+	"github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/token"
+	"github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/version"
+
+	"github.com/alecthomas/kong"
+	_ "github.com/joho/godotenv/autoload"
+)
+
+var cli struct {
+	Kubeconfig kubeconfig.Cmd `cmd:"kubeconfig" help:"Download a Kubeconfig from a Grafana instance with the \"Grafana Kubernetes Plugin\" installed."`
+	Token      token.Cmd      `cmd:"token" help:"Generate \"ExecCredential\" for a Kubeconfig downloaded via the \"kubeconfig\" command."`
+	Version    version.Cmd    `cmd:"version" help:"Show version information."`
+}
+
+func main() {
+	ctx := kong.Parse(&cli, kong.Name("kubectl grafana"))
+	err := ctx.Run()
+	if err != nil {
+		slog.Error("Failed to run command", slog.Any("error", err))
+		os.Exit(1)
+	}
+}

--- a/cmd/kubectl-grafana/token/cache.go
+++ b/cmd/kubectl-grafana/token/cache.go
@@ -1,0 +1,61 @@
+package token
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
+)
+
+type Cache struct {
+	cacheFile string
+}
+
+func NewCache(name string) (*Cache, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	cacheDir := filepath.Join(homeDir, ".kube", "cache", "kubectl-grafana")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return nil, err
+	}
+
+	return &Cache{
+		cacheFile: filepath.Join(cacheDir, name),
+	}, nil
+}
+
+func (c *Cache) Get() (*clientauthenticationv1.ExecCredential, error) {
+	data, err := os.ReadFile(c.cacheFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var execCredential clientauthenticationv1.ExecCredential
+	if err := json.Unmarshal(data, &execCredential); err != nil {
+		return nil, err
+	}
+
+	if execCredential.Status != nil && execCredential.Status.ExpirationTimestamp != nil {
+		if time.Now().After(execCredential.Status.ExpirationTimestamp.Time) {
+			return nil, nil
+		}
+	}
+
+	return &execCredential, nil
+}
+
+func (c *Cache) Set(credentials string) error {
+	if err := os.WriteFile(c.cacheFile, []byte(credentials), 0600); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/kubectl-grafana/token/token.go
+++ b/cmd/kubectl-grafana/token/token.go
@@ -1,0 +1,102 @@
+package token
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/utils"
+)
+
+type Cmd struct {
+	Name       string `default:"grafana" help:"Name of the Kubernetes cluster, which used for the cache file."`
+	Url        string `default:"" help:"Url of the Grafana instance, e.g. \"https://grafana.ricoberger.de/\"."`
+	Datasource string `default:"kubernetes" help:"Uid of the Kubernetes datasource."`
+}
+
+func (r *Cmd) Run() error {
+	// Validate that all required command-line flags are set. If a flag is
+	// missing return an error.
+	if r.Url == "" {
+		return fmt.Errorf("url is required")
+	}
+	if r.Datasource == "" {
+		return fmt.Errorf("datasource is required")
+	}
+	if r.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	// Initialize the cache and check if the cache contains valid credentials.
+	// If valid credentials are found, print them to stdout and return.
+	cache, err := NewCache(r.Name)
+	if err != nil {
+		return err
+	}
+
+	cachedCredentials, err := cache.Get()
+	if err != nil {
+		return err
+	} else if cachedCredentials != nil {
+		output, err := json.Marshal(cachedCredentials)
+		if err != nil {
+			return err
+		} else {
+			fmt.Fprintln(os.Stdout, string(output))
+			return nil
+		}
+	}
+
+	// Create the url, which can be used to create new credentails form the
+	// Grafana instance. It is important to set the
+	// "redirect=http://localhost:11716" query parameter, so that Grafana
+	// redirects the credentials to our local HTTP server.
+	credentialsUrl := fmt.Sprintf("%sapi/datasources/uid/%s/resources/kubernetes/kubeconfig/credentials?redirect=%s", r.Url, r.Datasource, url.QueryEscape("http://localhost:11716"))
+	credentials := ""
+	doneChannel := make(chan error)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// When the function is done, send the error (if any) to the
+		// "doneChannel", so that the main function can exit.
+		var err error
+
+		defer func() {
+			doneChannel <- err
+		}()
+
+		// Extrace the "credentials" query parameter from the redirect request
+		// and return an error if it is missing.
+		credentialsParam := r.URL.Query().Get("credentials")
+
+		if credentialsParam == "" {
+			err = fmt.Errorf("credentials parameter is missing in redirect")
+			return
+		}
+
+		credentials = credentialsParam
+		fmt.Fprintf(w, "Credentials were created")
+	})
+
+	// Start the HTTP server, which listens for the redirect from Grafana on
+	// port 11716.
+	// #nosec G114
+	go http.ListenAndServe(":11716", nil)
+
+	// Open the url in the users default browser and wait until Grafana
+	// redirects the user to our local HTTP server.
+	utils.OpenUrl(credentialsUrl)
+	err = <-doneChannel
+	if err != nil {
+		return err
+	}
+
+	// Store the new credentials in the cache and print them to stdout.
+	if err := cache.Set(credentials); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(os.Stdout, credentials)
+	return nil
+}

--- a/cmd/kubectl-grafana/utils/utils.go
+++ b/cmd/kubectl-grafana/utils/utils.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// OpenUrl opens the provided url in the users default browser.
+func OpenUrl(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start", url}
+	case "darwin":
+		cmd = "open"
+		args = []string{url}
+	default:
+		if isWSL() {
+			cmd = "cmd.exe"
+			args = []string{"/c", "start", url}
+		} else {
+			cmd = "xdg-open"
+			args = []string{url}
+		}
+	}
+	if len(args) > 1 {
+		args = append(args[:1], append([]string{""}, args[1:]...)...)
+	}
+	return exec.CommandContext(context.Background(), cmd, args...).Start()
+}
+
+func isWSL() bool {
+	releaseData, err := exec.CommandContext(context.Background(), "uname", "-r").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(releaseData)), "microsoft")
+}
+
+// ExpandEnv replaces all environment variables in the provided string. The
+// environment variables can be in the form `${var}` or `$var`. If the string
+// should contain a `$` it can be escaped via `$$`.
+func ExpandEnv(s string) string {
+	os.Setenv("CRANE_DOLLAR", "$")
+	return os.ExpandEnv(strings.ReplaceAll(s, "$$", "${CRANE_DOLLAR}"))
+}

--- a/cmd/kubectl-grafana/version/version.go
+++ b/cmd/kubectl-grafana/version/version.go
@@ -1,0 +1,50 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"text/template"
+)
+
+// Build information. Populated at build-time.
+var (
+	Version   string
+	Revision  string
+	Branch    string
+	BuildUser string
+	BuildDate string
+	GoVersion = runtime.Version()
+)
+
+var versionInfoTmpl = `
+{{.program}}, version {{.version}} (branch: {{.branch}}, revision: {{.revision}})
+  build user:       {{.buildUser}}
+  build date:       {{.buildDate}}
+  go version:       {{.goVersion}}
+`
+
+type Cmd struct {
+}
+
+func (r *Cmd) Run() error {
+	data := map[string]string{
+		"program":   "kubectl grafana",
+		"version":   Version,
+		"revision":  Revision,
+		"branch":    Branch,
+		"buildUser": BuildUser,
+		"buildDate": BuildDate,
+		"goVersion": GoVersion,
+	}
+
+	var buf bytes.Buffer
+
+	tmpl := template.Must(template.New("version").Parse(versionInfoTmpl))
+	tmpl.ExecuteTemplate(&buf, "version", data)
+
+	fmt.Fprintln(os.Stdout, strings.TrimSpace(buf.String()))
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/ricoberger/grafana-kubernetes-plugin
 go 1.24.6
 
 require (
+	github.com/alecthomas/kong v1.13.0
 	github.com/go-openapi/strfmt v0.24.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20250828163705-969607f81baa
 	github.com/grafana/grafana-plugin-sdk-go v0.281.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.39.0
 	github.com/testcontainers/testcontainers-go/modules/k3s v0.39.0
@@ -19,6 +21,7 @@ require (
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -229,7 +232,6 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 tool (

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,12 @@ github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
+github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/kong v1.13.0 h1:5e/7XC3ugvhP1DQBmTS+WuHtCbcv44hsohMgcvVxSrA=
+github.com/alecthomas/kong v1.13.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
+github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
+github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-go/v18 v18.4.1 h1:q/jVkBWCJOB9reDgaIZIdruLQUb1kbkvOnOFezVH1C4=
@@ -247,6 +253,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -257,6 +265,8 @@ github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5Xum
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -545,10 +545,10 @@ func (c *client) GetResource(ctx context.Context, resourceId string) (*Resource,
 //
 // Caddy (required for kubectl, because token is only send when https is used):
 //
-//	caddy run --config ./tmp/Caddyfile
+//	caddy run --config /tmp/Caddyfile
 //
 //	grafana.localhost {
-//	  reverse_proxy localhost:15219
+//	  reverse_proxy localhost:3000
 //	}
 func (c *client) Proxy(user string, groups []string, requestUrl string, w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracing.DefaultTracer().Start(r.Context(), "Proxy")

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -24,6 +24,7 @@ type PluginSettings struct {
 	GenerateKubeconfigName                 string                `json:"generateKubeconfigName"`
 	GenerateKubeconfigTTL                  int64                 `json:"generateKubeconfigTTL"`
 	GenerateKubeconfigPort                 int64                 `json:"generateKubeconfigPort"`
+	GenerateKubeconfigRedirectUrls         []string              `json:"generateKubeconfigRedirectUrls"`
 	IntegrationsMetricsDatasourceUid       string                `json:"integrationsMetricsDatasourceUid"`
 	IntegrationsMetricsKubeletJob          string                `json:"integrationsMetricsKubeletJob"`
 	IntegrationsMetricsKubeStateMetricsJob string                `json:"integrationsMetricsKubeStateMetricsJob"`

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -96,13 +96,14 @@ func NewDatasource(ctx context.Context, pCtx backend.DataSourceInstanceSettings)
 	}
 
 	ds := &Datasource{
-		generateKubeconfig:     config.GenerateKubeconfig,
-		generateKubeconfigName: config.GenerateKubeconfigName,
-		generateKubeconfigTTL:  config.GenerateKubeconfigTTL,
-		grafanaClient:          grafanaClient,
-		kubeClient:             kubeClient,
-		kubeServer:             kubeServer,
-		logger:                 logger,
+		generateKubeconfig:             config.GenerateKubeconfig,
+		generateKubeconfigName:         config.GenerateKubeconfigName,
+		generateKubeconfigTTL:          config.GenerateKubeconfigTTL,
+		generateKubeconfigRedirectUrls: config.GenerateKubeconfigRedirectUrls,
+		grafanaClient:                  grafanaClient,
+		kubeClient:                     kubeClient,
+		kubeServer:                     kubeServer,
+		logger:                         logger,
 	}
 
 	queryTypeMux := datasource.NewQueryTypeMux()
@@ -118,6 +119,7 @@ func NewDatasource(ctx context.Context, pCtx backend.DataSourceInstanceSettings)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/kubernetes/kubeconfig", ds.handleKubernetesKubeconfig)
+	mux.HandleFunc("/kubernetes/kubeconfig/credentials", ds.handleKubernetesKubeconfigCredentials)
 	mux.HandleFunc("/kubernetes/resource/{id}", ds.handleKubernetesResource)
 	mux.HandleFunc("/kubernetes/proxy/{pathname...}", ds.handleKubernetesProxy)
 	mux.HandleFunc("/helm/{namespace}/{name}/{version}", ds.handleHelmGetRelease)
@@ -131,15 +133,16 @@ func NewDatasource(ctx context.Context, pCtx backend.DataSourceInstanceSettings)
 // Datasource is an example datasource which can respond to data queries,
 // reports its health and has streaming skills.
 type Datasource struct {
-	generateKubeconfig     bool
-	generateKubeconfigName string
-	generateKubeconfigTTL  int64
-	queryHandler           backend.QueryDataHandler
-	resourceHandler        backend.CallResourceHandler
-	grafanaClient          grafana.Client
-	kubeClient             kubernetes.Client
-	kubeServer             kubernetes.Server
-	logger                 log.Logger
+	generateKubeconfig             bool
+	generateKubeconfigName         string
+	generateKubeconfigTTL          int64
+	generateKubeconfigRedirectUrls []string
+	queryHandler                   backend.QueryDataHandler
+	resourceHandler                backend.CallResourceHandler
+	grafanaClient                  grafana.Client
+	kubeClient                     kubernetes.Client
+	kubeServer                     kubernetes.Server
+	logger                         log.Logger
 }
 
 // CheckHealth handles health checks sent from Grafana to the plugin. The main

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -20,6 +20,8 @@ datasources:
       generateKubeconfigName: grafana
       generateKubeconfigTTL: 604800
       generateKubeconfigPort: 11716
+      generateKubeconfigRedirectUrls:
+        - http://localhost:11716
       integrationsMetricsDatasourceUid: prometheus
       integrationsMetricsKubeletJob: kubelet
       integrationsMetricsKubeStateMetricsJob: kube-state-metrics

--- a/src/datasource/components/configeditor/GenerateKubeconfig.tsx
+++ b/src/datasource/components/configeditor/GenerateKubeconfig.tsx
@@ -10,6 +10,7 @@ import {
   DataSourceOptions,
   KubernetesSecureJsonData,
 } from '../../types/settings';
+import { GenerateKubeconfigRedirectUrls } from './GenerateKubeconfigRedirectUrls';
 
 interface Props
   extends DataSourcePluginOptionsEditorProps<
@@ -105,6 +106,18 @@ export function GenerateKubeconfig({ options, onOptionsChange }: Props) {
           width={65}
         />
       </InlineField>
+      <GenerateKubeconfigRedirectUrls
+        redirectUrls={options.jsonData.generateKubeconfigRedirectUrls || []}
+        onChange={(redirectUrls) => {
+          onOptionsChange({
+            ...options,
+            jsonData: {
+              ...options.jsonData,
+              generateKubeconfigRedirectUrls: redirectUrls,
+            },
+          });
+        }}
+      />
     </div>
   );
 }

--- a/src/datasource/components/configeditor/GenerateKubeconfigRedirectUrls.tsx
+++ b/src/datasource/components/configeditor/GenerateKubeconfigRedirectUrls.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import {
+  Field,
+  IconButton,
+  InlineField,
+  InlineFieldRow,
+  Input,
+} from '@grafana/ui';
+
+interface Props {
+  redirectUrls: string[];
+  onChange: (redirectUrls: string[]) => void;
+}
+
+export function GenerateKubeconfigRedirectUrls({
+  redirectUrls,
+  onChange,
+}: Props) {
+  return (
+    <>
+      <Field label="Redirect Urls">
+        <IconButton
+          name="plus"
+          aria-label="Add redirect url"
+          onClick={(e) => {
+            e.preventDefault();
+            onChange([...redirectUrls, '']);
+          }}
+        />
+      </Field>
+
+      {redirectUrls.map((redirectUrl, index) => (
+        <InlineFieldRow key={index}>
+          <InlineField label="Redirect Url" labelWidth={20}>
+            <Input
+              width={40}
+              placeholder="http://localhost:11716"
+              value={redirectUrl}
+              onChange={(e) => {
+                const newRedirectUrls = [...redirectUrls];
+                newRedirectUrls[index] = e.currentTarget.value;
+                onChange(newRedirectUrls);
+              }}
+            />
+          </InlineField>
+          <IconButton
+            name="trash-alt"
+            aria-label="Remove redirect url"
+            onClick={(e) => {
+              e.preventDefault();
+              const newRedirectUrls = [...redirectUrls];
+              newRedirectUrls.splice(index, 1);
+              onChange(newRedirectUrls);
+            }}
+          />
+        </InlineFieldRow>
+      ))}
+    </>
+  );
+}

--- a/src/datasource/types/settings.ts
+++ b/src/datasource/types/settings.ts
@@ -23,6 +23,7 @@ export interface DataSourceOptions extends DataSourceJsonData {
   generateKubeconfigName?: string;
   generateKubeconfigTTL?: number;
   generateKubeconfigPort?: number;
+  generateKubeconfigRedirectUrls?: string[];
   integrationsMetricsDatasourceUid?: string;
   integrationsMetricsKubeletJob?: string;
   integrationsMetricsKubeStateMetricsJob?: string;


### PR DESCRIPTION
Add `kubectl-grafana` plugin, which can be used with `kubectl` to get a Kubeconfig and token from a Grafana instance with the Grafana Kubernetes Plugin installed.

To get a Kubeconfig and merge it with the Kubeconfig present in `$HOME/.kube/config` the following command can be used:

```sh
kubectl grafana kubeconfig --url http://localhost:3000/ --datasource kubernetes --kubeconfig $HOME/.kube/config
```

The Kubeconfig contains an exec command which is then used to get a token. The command which is used looks as follows:

```sh
kubectl grafana token --url http://localhost:3000/ --datasource kubernetes --name grafana
```