### PR TITLE
Use Frontend for Redirect in `kubectl-grafana`

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ contains a Kubeconfig it will be merged, with the downloaded Kubeconfig having a
 higher priority.
 
 ```bash
-kubectl grafana kubeconfig --url <GRAFANA-INSTANCE-URL> --datasource <DATASOURCE-UID> --kubeconfig <PATH-TO-KUBECONFIG-FILE>
+kubectl grafana kubeconfig --grafana-url <GRAFANA-INSTANCE-URL> --grafana-datasource <DATASOURCE-UID> --kubeconfig <PATH-TO-KUBECONFIG-FILE>
 ```
 
 ### Integrations

--- a/cmd/kubectl-grafana/credentials/credentials.go
+++ b/cmd/kubectl-grafana/credentials/credentials.go
@@ -1,4 +1,4 @@
-package token
+package credentials
 
 import (
 	"encoding/json"
@@ -12,27 +12,23 @@ import (
 )
 
 type Cmd struct {
-	Name       string `default:"grafana" help:"Name of the Kubernetes cluster, which used for the cache file."`
-	Url        string `default:"" help:"Url of the Grafana instance, e.g. \"https://grafana.ricoberger.de/\"."`
-	Datasource string `default:"kubernetes" help:"Uid of the Kubernetes datasource."`
+	GrafanaUrl        string `default:"" help:"Url of the Grafana instance, e.g. \"https://play.grafana.org/\"."`
+	GrafanaDatasource string `default:"kubernetes" help:"Uid of the Kubernetes datasource."`
 }
 
 func (r *Cmd) Run() error {
 	// Validate that all required command-line flags are set. If a flag is
 	// missing return an error.
-	if r.Url == "" {
-		return fmt.Errorf("url is required")
+	if r.GrafanaUrl == "" {
+		return fmt.Errorf("grafana url is required")
 	}
-	if r.Datasource == "" {
-		return fmt.Errorf("datasource is required")
-	}
-	if r.Name == "" {
-		return fmt.Errorf("name is required")
+	if r.GrafanaDatasource == "" {
+		return fmt.Errorf("grafana datasource is required")
 	}
 
 	// Initialize the cache and check if the cache contains valid credentials.
 	// If valid credentials are found, print them to stdout and return.
-	cache, err := NewCache(r.Name)
+	cache, err := utils.NewCache(r.GrafanaUrl, r.GrafanaDatasource)
 	if err != nil {
 		return err
 	}
@@ -54,7 +50,7 @@ func (r *Cmd) Run() error {
 	// Grafana instance. It is important to set the
 	// "redirect=http://localhost:11716" query parameter, so that Grafana
 	// redirects the credentials to our local HTTP server.
-	credentialsUrl := fmt.Sprintf("%sapi/datasources/uid/%s/resources/kubernetes/kubeconfig/credentials?redirect=%s", r.Url, r.Datasource, url.QueryEscape("http://localhost:11716"))
+	credentialsUrl := fmt.Sprintf("%sa/ricoberger-kubernetes-app/kubectl?type=credentials&datasource=%s&redirect=%s", r.GrafanaUrl, r.GrafanaDatasource, url.QueryEscape("http://localhost:11716"))
 	credentials := ""
 	doneChannel := make(chan error)
 

--- a/cmd/kubectl-grafana/kubeconfig/kubeconfig.go
+++ b/cmd/kubectl-grafana/kubeconfig/kubeconfig.go
@@ -16,29 +16,29 @@ import (
 )
 
 type Cmd struct {
-	Url        string `default:"" help:"Url of the Grafana instance, e.g. \"https://grafana.ricoberger.de/\"."`
-	Datasource string `default:"kubernetes" help:"Uid of the Kubernetes datasource."`
-	Kubeconfig string `default:"$HOME/.kube/config" help:"The file to which the Kubeconfig should be written."`
+	GrafanaUrl        string `default:"" help:"Url of the Grafana instance, e.g. \"https://play.grafana.org/\"."`
+	GrafanaDatasource string `default:"kubernetes" help:"Uid of the Kubernetes datasource."`
+	Kubeconfig        string `default:"$HOME/.kube/config" help:"Path to the Kubeconfig file."`
 }
 
 func (r *Cmd) Run() error {
 	// Validate that all required command-line flags are set. If a flag is
 	// missing return an error.
-	if r.Url == "" {
-		return fmt.Errorf("url is required")
+	if r.GrafanaUrl == "" {
+		return fmt.Errorf("grafana url is required")
 	}
-	if r.Datasource == "" {
-		return fmt.Errorf("datasource is required")
+	if r.GrafanaDatasource == "" {
+		return fmt.Errorf("grafana datasource is required")
 	}
 	if r.Kubeconfig == "" {
 		return fmt.Errorf("kubeconfig is required")
 	}
 
 	// Create the url, which can be used to download the Kubeconfig from the
-	// Grafana instance. It is important to set the "type=exec" and
+	// Grafana instance. It is important to set the
 	// "redirect=http://localhost:11716" query parameters, so that Grafana
 	// redirects the Kubeconfig to our local HTTP server.
-	kubeconfigUrl := fmt.Sprintf("%sapi/datasources/uid/%s/resources/kubernetes/kubeconfig?type=exec&redirect=%s", r.Url, r.Datasource, url.QueryEscape("http://localhost:11716"))
+	kubeconfigUrl := fmt.Sprintf("%sa/ricoberger-kubernetes-app/kubectl?type=kubeconfig&datasource=%s&redirect=%s", r.GrafanaUrl, r.GrafanaDatasource, url.QueryEscape("http://localhost:11716"))
 	kubeconfigFile := utils.ExpandEnv(r.Kubeconfig)
 	doneChannel := make(chan error)
 

--- a/cmd/kubectl-grafana/main.go
+++ b/cmd/kubectl-grafana/main.go
@@ -4,8 +4,8 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/credentials"
 	"github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/kubeconfig"
-	"github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/token"
 	"github.com/ricoberger/grafana-kubernetes-plugin/cmd/kubectl-grafana/version"
 
 	"github.com/alecthomas/kong"
@@ -13,9 +13,9 @@ import (
 )
 
 var cli struct {
-	Kubeconfig kubeconfig.Cmd `cmd:"kubeconfig" help:"Download a Kubeconfig from a Grafana instance with the \"Grafana Kubernetes Plugin\" installed."`
-	Token      token.Cmd      `cmd:"token" help:"Generate \"ExecCredential\" for a Kubeconfig downloaded via the \"kubeconfig\" command."`
-	Version    version.Cmd    `cmd:"version" help:"Show version information."`
+	Kubeconfig  kubeconfig.Cmd  `cmd:"kubeconfig" help:"Download a Kubeconfig from a Grafana instance with the \"Grafana Kubernetes Plugin\" installed."`
+	Credentials credentials.Cmd `cmd:"credentials" help:"Generate \"ExecCredential\" for a Kubeconfig downloaded via the \"kubeconfig\" command."`
+	Version     version.Cmd     `cmd:"version" help:"Show version information."`
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/grafana/grafana-plugin-sdk-go v0.281.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/joho/godotenv v1.5.1
+	github.com/magefile/mage v1.15.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.39.0
 	github.com/testcontainers/testcontainers-go/modules/k3s v0.39.0
@@ -122,7 +123,6 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-	github.com/magefile/mage v1.15.0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattetti/filebuffer v1.0.1 // indirect

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { initPluginTranslations } from '@grafana/i18n';
 import { PluginPropsContext } from '../utils/utils.plugin';
 import { HomePage } from '../pages/home/HomePage';
 import { KubeconfigPage } from '../pages/kubeconfig/KubeconfigPage';
+import { KubectlPage } from '../pages/kubectl/KubectlPage';
 import { ResourcesPage } from '../pages/resources/ResourcesPage';
 import { HelmPage } from '../pages/helm/HelmPage';
 import { FluxPage } from '../pages/flux/FluxPage';
@@ -20,7 +21,14 @@ initPluginTranslations('ricoberger-kubernetes-app');
 
 function getSceneApp() {
   return new SceneApp({
-    pages: [HomePage, ResourcesPage, HelmPage, FluxPage, KubeconfigPage],
+    pages: [
+      HomePage,
+      ResourcesPage,
+      HelmPage,
+      FluxPage,
+      KubeconfigPage,
+      KubectlPage,
+    ],
     urlSyncOptions: {
       updateUrlOnInit: true,
       createBrowserHistorySteps: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,4 +8,5 @@ export enum ROUTES {
   Helm = 'helm',
   Flux = 'flux',
   Kubeconfig = 'kubeconfig',
+  Kubectl = 'kubectl',
 }

--- a/src/pages/kubectl/Kubectl.tsx
+++ b/src/pages/kubectl/Kubectl.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {
+  SceneComponentProps,
+  SceneObjectBase,
+  SceneObjectState,
+} from '@grafana/scenes';
+import { Alert, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { useAsync } from 'react-use';
+
+interface KubectlState extends SceneObjectState { }
+
+export class Kubectl extends SceneObjectBase<KubectlState> {
+  static Component = KubectlRenderer;
+}
+
+function KubectlRenderer({ }: SceneComponentProps<Kubectl>) {
+  const styles = useStyles2(() => {
+    return {
+      container: css({
+        width: '100%',
+      }),
+    };
+  });
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const type = urlParams.get('type');
+  const datasource = urlParams.get('datasource');
+  const redirect = urlParams.get('redirect');
+
+  const state = useAsync(async (): Promise<void> => {
+    let url = '';
+    if (type === 'kubeconfig') {
+      url = `/api/datasources/uid/${datasource}/resources/kubernetes/kubeconfig?type=exec&redirect=${redirect}`;
+    } else if (type === 'credentials') {
+      url = `/api/datasources/uid/${datasource}/resources/kubernetes/kubeconfig/credentials?redirect=${redirect}`;
+    }
+
+    const response = await fetch(url, { method: 'get' });
+    if (!response.ok) {
+      throw new Error(await response.text());
+    }
+
+    const result = await response.json();
+
+    window.location.replace(
+      `${redirect}?${type}=${encodeURIComponent(JSON.stringify(result))}`,
+    );
+  }, []);
+
+  return (
+    <>
+      <div className={styles.container}>
+        {state.loading ? (
+          <LoadingPlaceholder text={`Loading ${type}...`} />
+        ) : state.error ? (
+          <Alert severity="error" title={`Failed to load ${type}`}>
+            {state.error.message}
+          </Alert>
+        ) : (
+          <LoadingPlaceholder text={'Redirecting...'} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/pages/kubectl/KubectlPage.ts
+++ b/src/pages/kubectl/KubectlPage.ts
@@ -1,0 +1,14 @@
+import { SceneAppPage } from '@grafana/scenes';
+
+import { KubectlScene } from './KubectlScene';
+import { prefixRoute } from '../../utils/utils.routing';
+import { ROUTES } from '../../constants';
+import kubernetesImg from '../../img/logo.svg';
+
+export const KubectlPage = new SceneAppPage({
+  title: 'kubectl',
+  url: prefixRoute(ROUTES.Kubectl),
+  routePath: ROUTES.Kubectl,
+  titleImg: kubernetesImg,
+  getScene: () => KubectlScene(),
+});

--- a/src/pages/kubectl/KubectlScene.ts
+++ b/src/pages/kubectl/KubectlScene.ts
@@ -1,0 +1,11 @@
+import { EmbeddedScene } from '@grafana/scenes';
+
+import { Kubectl } from './Kubectl';
+
+export function KubectlScene() {
+  const kubectl = new Kubectl({});
+
+  return new EmbeddedScene({
+    body: kubectl,
+  });
+}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -117,6 +117,13 @@
       "path": "/a/%PLUGIN_ID%/kubeconfig",
       "addToNav": true,
       "defaultNav": false
+    },
+    {
+      "type": "page",
+      "name": "kubectl",
+      "path": "/a/%PLUGIN_ID%/kubectl",
+      "addToNav": false,
+      "defaultNav": false
     }
   ],
   "dependencies": {


### PR DESCRIPTION
Instead of directly calling the API of the Kubernetes datasource to get
a Kubeconfig / credentials, we are now opening the Grafana frontend,
which calls the API to get the data and then redirects to the
`kubectl-grafana` command.

This is done, because when we directly call the API and the user is not
authenticated, Grafana will return an error. When we open the Grafana
frontend, the user is redirect to the authentication page first.

This commit also renames the `token` command to `credentials`.
