### PR TITLE
Add Tail Option for Kubernetes Logs Query

### DIFF
--- a/pkg/kubernetes/client_mock.go
+++ b/pkg/kubernetes/client_mock.go
@@ -74,18 +74,18 @@ func (mr *MockClientMockRecorder) GetContainers(ctx, user, groups, resourceId, n
 }
 
 // GetLogs mocks base method.
-func (m *MockClient) GetLogs(ctx context.Context, user string, groups []string, resourceId, namespace, name, container, filter string, timeRange backend.TimeRange) (*data.Frame, error) {
+func (m *MockClient) GetLogs(ctx context.Context, user string, groups []string, resourceId, namespace, name, container, filter string, tail int64, timeRange backend.TimeRange) (*data.Frame, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogs", ctx, user, groups, resourceId, namespace, name, container, filter, timeRange)
+	ret := m.ctrl.Call(m, "GetLogs", ctx, user, groups, resourceId, namespace, name, container, filter, tail, timeRange)
 	ret0, _ := ret[0].(*data.Frame)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLogs indicates an expected call of GetLogs.
-func (mr *MockClientMockRecorder) GetLogs(ctx, user, groups, resourceId, namespace, name, container, filter, timeRange any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetLogs(ctx, user, groups, resourceId, namespace, name, container, filter, tail, timeRange any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockClient)(nil).GetLogs), ctx, user, groups, resourceId, namespace, name, container, filter, timeRange)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockClient)(nil).GetLogs), ctx, user, groups, resourceId, namespace, name, container, filter, tail, timeRange)
 }
 
 // GetNamespaces mocks base method.

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -169,7 +169,7 @@ func TestGetLogs(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("should return logs", func(t *testing.T) {
-		actualLogs, err := client.GetLogs(context.Background(), "", nil, "pod", "default", "echoserver", "echoserver", "", backend.TimeRange{From: time.Now().Add(-1 * time.Hour), To: time.Now().Add(1 * time.Hour)})
+		actualLogs, err := client.GetLogs(context.Background(), "", nil, "pod", "default", "echoserver", "echoserver", "", 0, backend.TimeRange{From: time.Now().Add(-1 * time.Hour), To: time.Now().Add(1 * time.Hour)})
 		require.NoError(t, err)
 		require.Equal(t, "timestamp", actualLogs.Fields[0].Name)
 		require.Equal(t, "body", actualLogs.Fields[1].Name)
@@ -187,7 +187,7 @@ func TestGetLogs(t *testing.T) {
 	})
 
 	t.Run("should return filtered logs", func(t *testing.T) {
-		actualLogs, err := client.GetLogs(context.Background(), "", nil, "pod", "default", "echoserver", "echoserver", "build", backend.TimeRange{From: time.Now().Add(-1 * time.Hour), To: time.Now().Add(1 * time.Hour)})
+		actualLogs, err := client.GetLogs(context.Background(), "", nil, "pod", "default", "echoserver", "echoserver", "build", 0, backend.TimeRange{From: time.Now().Add(-1 * time.Hour), To: time.Now().Add(1 * time.Hour)})
 		require.NoError(t, err)
 		require.Equal(t, "timestamp", actualLogs.Fields[0].Name)
 		require.Equal(t, "body", actualLogs.Fields[1].Name)

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -33,6 +33,7 @@ type QueryModelKubernetesLogs struct {
 	Name       string `json:"name"`
 	Container  string `json:"container"`
 	Filter     string `json:"filter"`
+	Tail       int64  `json:"tail"`
 }
 
 type QueryModelHelmReleases struct {

--- a/pkg/plugin/kubernetes.go
+++ b/pkg/plugin/kubernetes.go
@@ -233,7 +233,7 @@ func (d *Datasource) handleKubernetesLogs(ctx context.Context, query concurrent.
 		return backend.ErrorResponseWithErrorSource(err)
 	}
 
-	d.logger.Info("handleKubernetesLogs query", "user", user, "groups", groups, "resourceId", qm.ResourceId, "namespace", qm.Namespace, "name", qm.Name, "container", qm.Container, "filter", qm.Filter)
+	d.logger.Info("handleKubernetesLogs query", "user", user, "groups", groups, "resourceId", qm.ResourceId, "namespace", qm.Namespace, "name", qm.Name, "container", qm.Container, "filter", qm.Filter, "tail", qm.Tail)
 	span.SetAttributes(attribute.Key("user").String(user))
 	span.SetAttributes(attribute.Key("groups").StringSlice(groups))
 	span.SetAttributes(attribute.Key("resourceId").String(qm.ResourceId))
@@ -241,8 +241,9 @@ func (d *Datasource) handleKubernetesLogs(ctx context.Context, query concurrent.
 	span.SetAttributes(attribute.Key("name").String(qm.Name))
 	span.SetAttributes(attribute.Key("container").String(qm.Container))
 	span.SetAttributes(attribute.Key("filter").String(qm.Filter))
+	span.SetAttributes(attribute.Key("tail").Int64(qm.Tail))
 
-	frame, err := d.kubeClient.GetLogs(ctx, user, groups, qm.ResourceId, qm.Namespace, qm.Name, qm.Container, qm.Filter, query.DataQuery.TimeRange)
+	frame, err := d.kubeClient.GetLogs(ctx, user, groups, qm.ResourceId, qm.Namespace, qm.Name, qm.Container, qm.Filter, qm.Tail, query.DataQuery.TimeRange)
 	if err != nil {
 		d.logger.Error("Failed to get logs", "error", err.Error())
 		span.RecordError(err)

--- a/src/datasource/components/queryeditor/KubernetesLogs.tsx
+++ b/src/datasource/components/queryeditor/KubernetesLogs.tsx
@@ -79,6 +79,14 @@ export function KubernetesLogs({
         />
       </InlineFieldRow>
       <InlineFieldRow>
+        <InlineField label="Tail">
+          <Input
+            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+              onChange({ ...query, tail: parseInt(event.target.value, 10) });
+            }}
+            value={query.tail || 0}
+          />
+        </InlineField>
         <InlineField label="Filter" grow={true}>
           <Input
             id="query-editor-filter"

--- a/src/datasource/types/query.ts
+++ b/src/datasource/types/query.ts
@@ -44,6 +44,7 @@ export const DEFAULT_QUERIES: Record<QueryType, Partial<Query>> = {
     name: '',
     container: '',
     filter: '',
+    tail: 0,
   },
   'helm-releases': {
     namespace: 'default',
@@ -116,6 +117,7 @@ export interface QueryModelKubernetesLogs {
   name?: string;
   container?: string;
   filter?: string;
+  tail?: number;
 }
 
 export interface QueryModelHelmReleases {


### PR DESCRIPTION
It is now possible to specify a `tail` options when querying Kubernetes
logs. This allows user to limit the results of a query to the last `n`
lines of logs. By default the tail option is set to 0, which means no
limit.
