### PR TITLE
Add Streaming Support for Kubernetes Logs

### DIFF
--- a/pkg/kubernetes/client_mock.go
+++ b/pkg/kubernetes/client_mock.go
@@ -173,3 +173,17 @@ func (mr *MockClientMockRecorder) RestConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestConfig", reflect.TypeOf((*MockClient)(nil).RestConfig))
 }
+
+// StreamLogs mocks base method.
+func (m *MockClient) StreamLogs(ctx context.Context, user string, groups []string, resourceId, namespace, name, container, filter string, sender *backend.StreamSender) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamLogs", ctx, user, groups, resourceId, namespace, name, container, filter, sender)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StreamLogs indicates an expected call of StreamLogs.
+func (mr *MockClientMockRecorder) StreamLogs(ctx, user, groups, resourceId, namespace, name, container, filter, sender any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamLogs", reflect.TypeOf((*MockClient)(nil).StreamLogs), ctx, user, groups, resourceId, namespace, name, container, filter, sender)
+}

--- a/src/datasource/plugin.json
+++ b/src/datasource/plugin.json
@@ -5,6 +5,7 @@
   "id": "ricoberger-kubernetes-datasource",
   "metrics": true,
   "logs": true,
+  "streaming": true,
   "backend": true,
   "executable": "gpx_kubernetes",
   "info": {


### PR DESCRIPTION
If a user selects the "Kubernetes: Logs" query type, it is now possible
to stream logs in real-time.
