### PR TITLE
Improve Naming of Data Frames

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -237,7 +237,7 @@ func (c *client) GetResources(ctx context.Context, user string, groups []string,
 		return nil, errors[0]
 	}
 
-	return createResourcesDataFrame(resourceId, resources, resource.Namespaced, wide)
+	return createResourcesDataFrame(resource, resources, resource.Namespaced, wide)
 }
 
 // GetContainer returns a list of all containers for the requested resource

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -72,9 +72,9 @@ func (c *client) getResources(ctx context.Context) (map[string]Resource, error) 
 // data. The resources JSON data is expected to be in the format of a Kubernetes
 // Table object. If the wide parameter is true, all columns are included in the
 // data frame, otherwise only the columns with priority 0 are included.
-func createResourcesDataFrame(resourceId string, resources [][]byte, namespaced, wide bool) (*data.Frame, error) {
+func createResourcesDataFrame(resource Resource, resources [][]byte, namespaced, wide bool) (*data.Frame, error) {
 	table := metav1.Table{}
-	frame := data.NewFrame("Resources")
+	frame := data.NewFrame(resource.Kind)
 
 	// Go through all resources responses and fill the global "table" with the
 	// column definition and rows from the responses.
@@ -115,11 +115,11 @@ func createResourcesDataFrame(resourceId string, resources [][]byte, namespaced,
 
 		var values []string
 		for _, row := range table.Rows {
-			values = append(values, formatValue(resourceId, column.Name, row.Cells[columnIndex]))
+			values = append(values, formatValue(resource.ID, column.Name, row.Cells[columnIndex]))
 		}
 
 		frame.Fields = append(frame.Fields,
-			data.NewField(formatColumnName(resourceId, column.Name), nil, values),
+			data.NewField(formatColumnName(resource.ID, column.Name), nil, values),
 		)
 	}
 


### PR DESCRIPTION
Improve the naming of data frames, so that if multiple queries are used
within the same table, a user can differentiate between them more
easily.
