### PR TITLE
Add Basic JSONPath Support for Filtering Resources

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
 
   jaeger:
     container_name: grafana-jaeger
-    image: cr.jaegertracing.io/jaegertracing/jaeger:2.10.0
+    image: jaegertracing/jaeger:2.14.0
 
   k3s:
     container_name: grafana-k3s

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -195,6 +195,16 @@ func (c *client) GetResources(ctx context.Context, user string, groups []string,
 		namespace = ""
 	}
 	namespaces := strings.Split(namespace, ",")
+
+	// Check if the parameter name is "jsonPath". If this is the case, we remove
+	// the parameter name and value to get all resources without filtering,
+	// because we will apply the JSONPath later when creating the data frame.
+	var jsonPath string
+	if parameterName == "jsonPath" {
+		jsonPath = parameterValue
+		parameterName = ""
+		parameterValue = ""
+	}
 	parameterValues := strings.Split(parameterValue, "||")
 
 	var errors []error
@@ -237,7 +247,7 @@ func (c *client) GetResources(ctx context.Context, user string, groups []string,
 		return nil, errors[0]
 	}
 
-	return createResourcesDataFrame(resource, resources, resource.Namespaced, wide)
+	return createResourcesDataFrame(c.logger, resource, resources, resource.Namespaced, wide, jsonPath)
 }
 
 // GetContainer returns a list of all containers for the requested resource

--- a/src/datasource/components/queryeditor/KubernetesResources.tsx
+++ b/src/datasource/components/queryeditor/KubernetesResources.tsx
@@ -58,6 +58,7 @@ export function KubernetesResources({
               { label: 'None', value: '' },
               { label: 'Label', value: 'labelSelector' },
               { label: 'Field', value: 'fieldSelector' },
+              { label: 'JSONPath', value: 'jsonPath' },
             ]}
             value={query.parameterName || ''}
             onChange={(value: string) => {
@@ -75,7 +76,8 @@ export function KubernetesResources({
           grow={true}
           disabled={
             query.parameterName !== 'labelSelector' &&
-            query.parameterName !== 'fieldSelector'
+            query.parameterName !== 'fieldSelector' &&
+            query.parameterName !== 'jsonPath'
           }
         >
           <Input


### PR DESCRIPTION
It is now possible to filter the list of returned Kubernetes resources
using JSONPath expressions. For example, we can now retrieve the Jobs
for a CronJob by specifying the following JSONPath expression:
`[?(@.metadata.ownerReferences[0].name=='myjobname')]`.

NOTE: The JSONPath can only be applied to the metadata of the resource,
because we still using the `Accept` header with a value of
`application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io,application/json`
which only returns the partial metadata of the resource in the response.
