### PR TITLE
Improve JSONPath Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Helm and Flux.
 - View Kubernetes resources like Pods, DaemonSets, Deployments, StatefulSets,
   etc.
 - Includes support for Custom Resource Definitions.
-- Filter and search for resources, by Namespace, label selectors and field
-  selectors.
+- Filter and search for resources, by Namespace, label selectors, field
+  selectors or JSONPath (for example the following JSONPath filter can be used
+  to get all Jobs for a CronJob with the name `mycronjob`:
+  `{.items[?(@.metadata.ownerReferences[0].name=='mycronjob')]}`).
 - Get a fast overview of the status of resources, including detailed information
   and events.
 - Modify resources, by adjusting the YAML manifest files or using the built-in

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -1,20 +1,17 @@
 package kubernetes
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/codes"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/jsonpath"
 )
 
 func (c *client) getResources(ctx context.Context) (map[string]Resource, error) {
@@ -75,7 +72,7 @@ func (c *client) getResources(ctx context.Context) (map[string]Resource, error) 
 // data. The resources JSON data is expected to be in the format of a Kubernetes
 // Table object. If the wide parameter is true, all columns are included in the
 // data frame, otherwise only the columns with priority 0 are included.
-func createResourcesDataFrame(logger log.Logger, resource Resource, resources [][]byte, namespaced, wide bool, jsonPath string) (*data.Frame, error) {
+func createResourcesDataFrame(resource Resource, resources [][]byte, resourcesJSONPath []NamespacedName, hasJSONPath, wide bool) (*data.Frame, error) {
 	table := metav1.Table{}
 	frame := data.NewFrame(resource.Kind)
 
@@ -88,58 +85,50 @@ func createResourcesDataFrame(logger log.Logger, resource Resource, resources []
 			return nil, err
 		}
 
-		table.ColumnDefinitions = tmpTable.ColumnDefinitions
+		// If the resource is a namespaced resource, we need to add the
+		// namespace as first column in the table, because the Kubernetes API
+		// does not include the namespace in the column definitions.
+		if resource.Namespaced {
+			namespaceColumnDefinition := metav1.TableColumnDefinition{
+				Name:     "Namespace",
+				Type:     "string",
+				Priority: 0,
+			}
+			table.ColumnDefinitions = append([]metav1.TableColumnDefinition{namespaceColumnDefinition}, tmpTable.ColumnDefinitions...)
+		} else {
+			table.ColumnDefinitions = tmpTable.ColumnDefinitions
+		}
 
 		for _, row := range tmpTable.Rows {
-			// If a JSONPath filter is provided, we need to evaluate it against
-			// all the rows and only include the ones that match.
-			// NOTE: The object in the row only contains partial metadata, so we
-			// can only filter on the metadata for now.
-			if jsonPath != "" {
-				var objects []metav1.PartialObjectMetadata
-				var object metav1.PartialObjectMetadata
-				if err := json.Unmarshal(row.Object.Raw, &object); err != nil {
-					return nil, err
-				}
-				objects = append(objects, object)
+			var metadata metav1.PartialObjectMetadata
+			if err := json.Unmarshal(row.Object.Raw, &metadata); err != nil {
+				return nil, err
+			}
 
-				_, found, err := executeJSONPath(logger, jsonPath, objects)
-				if err != nil {
-					return nil, err
-				}
+			// If a JSONPath filter was provided, we need to check if the
+			// current resource is in the list of JSONPath resources.
+			if hasJSONPath && !isInNamespacedNames(resourcesJSONPath, metadata.Namespace, metadata.Name) {
+				continue
+			}
 
-				if found {
-					table.Rows = append(table.Rows, row)
-				}
+			// If the resource is namespaced, we need to add the namespace
+			// as first cell in the row, because the Kubernetes API does not
+			// include the namespace in the row cells.
+			if resource.Namespaced {
+				row.Cells = append([]any{metadata.Namespace}, row.Cells...)
+				table.Rows = append(table.Rows, row)
 			} else {
 				table.Rows = append(table.Rows, row)
 			}
 		}
 	}
 
-	// If the resource is a namespaced resource, we include the namespace as
-	// first field in the data frame.
-	//
-	// We also create a unique slice of rows, to avoid duplicate entries in the
-	// data frame.
-	if namespaced {
-		var values []string
-		for _, row := range table.Rows {
-			var metadata metav1.PartialObjectMetadata
-			if err := json.Unmarshal(row.Object.Raw, &metadata); err != nil {
-				return nil, err
-			}
-			values = append(values, metadata.Namespace)
-		}
-
-		table.Rows, values = unique(table.Rows, values)
-
-		frame.Fields = append(frame.Fields,
-			data.NewField("Namespace", nil, values),
-		)
-	} else {
-		table.Rows, _ = unique(table.Rows, make([]string, len(table.Rows)))
-	}
+	// Since we support or conditions in the label selector, it might be
+	// possible that we fetched the same resource multiple times. To avoid
+	// duplicate entries in the data frame, we need to filter the rows to be
+	// unique based on the namespace (if resource is namespaced) and name of the
+	// resource.
+	table.Rows = unique(table.Rows, resource.Namespaced)
 
 	// Loop through all columns and rows to create the data frame. Depending on
 	// the "wide" parameter we add all columns or only the ones with priority 0.
@@ -198,43 +187,32 @@ func formatValue(resourceId, name string, value any) string {
 	return fmt.Sprintf("%v", value)
 }
 
-func executeJSONPath(logger log.Logger, tmpl string, input any) (string, bool, error) {
-	jsonPath := jsonpath.New("")
-
-	if err := jsonPath.Parse(fmt.Sprintf("{%s}", tmpl)); err != nil {
-		return "", false, fmt.Errorf("error parsing jsonpath: %w", err)
+func isInNamespacedNames(namespacedNames []NamespacedName, namespace, name string) bool {
+	for _, nn := range namespacedNames {
+		if nn.Namespace == namespace && nn.Name == name {
+			return true
+		}
 	}
-
-	resultBuf := &bytes.Buffer{}
-	if err := jsonPath.Execute(resultBuf, input); err != nil {
-		logger.Debug("error executing jsonpath", "error", err.Error())
-		return "", false, nil
-	}
-
-	if strings.TrimSpace(resultBuf.String()) == "" {
-		return "", false, nil
-	}
-
-	return resultBuf.String(), true, nil
+	return false
 }
 
-// Since we support or conditions in the label selector, it might be possible
-// that we fetched the same resource multiple times. To avoid duplicate entries
-// in the data frame, we need to filter the rows to be unique based on the first
-// column (which is always the name of the resource).
-func unique(rows []metav1.TableRow, namespaces []string) ([]metav1.TableRow, []string) {
+func unique(rows []metav1.TableRow, namespaced bool) []metav1.TableRow {
 	var uniqueRows []metav1.TableRow
-	var uniqueNamespaces []string
 	keys := make(map[string]struct{})
 
-	for index, row := range rows {
-		key := namespaces[index] + row.Cells[0].(string)
+	for _, row := range rows {
+		var key string
+		if namespaced {
+			key = row.Cells[0].(string) + "_" + row.Cells[1].(string)
+		} else {
+			key = row.Cells[0].(string)
+		}
+
 		if _, exists := keys[key]; !exists {
 			keys[key] = struct{}{}
 			uniqueRows = append(uniqueRows, row)
-			uniqueNamespaces = append(uniqueNamespaces, namespaces[index])
 		}
 	}
 
-	return uniqueRows, uniqueNamespaces
+	return uniqueRows
 }

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -19,6 +19,11 @@ type Resource struct {
 	Namespaced bool   `json:"namespaced"`
 }
 
+type NamespacedName struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
 // Stream represents a logs stream for a single pod. It contains the "Pod" name
 // and the actual "Stream".
 type Stream struct {

--- a/src/datasource/components/certmanager/CertificateRequests.tsx
+++ b/src/datasource/components/certmanager/CertificateRequests.tsx
@@ -28,7 +28,7 @@ export function CertificateRequests({ datasource, namespace, name }: Props) {
         resourceId: 'certificaterequest.cert-manager.io',
         namespace: namespace,
         parameterName: 'jsonPath',
-        parameterValue: `[?(@.metadata.annotations.cert-manager\\.io/certificate-name=='${name}')]`,
+        parameterValue: `{.items[?(@.metadata.annotations.cert-manager\\.io/certificate-name=='${name}')]}`,
       },
     ],
   });


### PR DESCRIPTION
Improve the JSONPath support in the Kubernetes datasource. Resources can
now be filtered using JSONPath expressions on the complete resource
manifest and not just for the metadata fields.

The JSONPath expressions must now look as follows:
`{.items[?(@.metadata.ownerReferences[0].name=='mycronjob')]}`
