### PR TITLE
cert-manager: Show Related Resources in Details

### DIFF
--- a/src/datasource/components/certmanager/Details.tsx
+++ b/src/datasource/components/certmanager/Details.tsx
@@ -11,6 +11,7 @@ import { Events } from '../shared/details/Events';
 import { Overview } from './Overview';
 import { AI } from './AI';
 import { CertificateRequests } from './CertificateRequests';
+import { IssuerRefs } from './IssuerRefs';
 
 initPluginTranslations('ricoberger-kubernetes-app');
 
@@ -93,6 +94,43 @@ export function Details({
                 }}
               />
             )}
+            {(resourceId === 'clusterissuer.cert-manager.io' ||
+              resourceId === 'issuer.cert-manager.io') && (
+                <>
+                  <Tab
+                    label="Certificates"
+                    active={activeTab === 'issuerref-certificates'}
+                    onChangeTab={(ev) => {
+                      ev?.preventDefault();
+                      setActiveTab('issuerref-certificates');
+                    }}
+                  />
+                  <Tab
+                    label="CertificateRequests"
+                    active={activeTab === 'issuerref-certificaterequests'}
+                    onChangeTab={(ev) => {
+                      ev?.preventDefault();
+                      setActiveTab('issuerref-certificaterequests');
+                    }}
+                  />
+                  <Tab
+                    label="Orders"
+                    active={activeTab === 'issuerref-orders'}
+                    onChangeTab={(ev) => {
+                      ev?.preventDefault();
+                      setActiveTab('issuerref-orders');
+                    }}
+                  />
+                  <Tab
+                    label="Challenges"
+                    active={activeTab === 'issuerref-challenges'}
+                    onChangeTab={(ev) => {
+                      ev?.preventDefault();
+                      setActiveTab('issuerref-challenges');
+                    }}
+                  />
+                </>
+              )}
             {ai.value && (
               <Tab
                 label="AI"
@@ -136,6 +174,42 @@ export function Details({
               datasource={datasource}
               namespace={namespace}
               name={name}
+            />
+          )}
+          {activeTab === 'issuerref-certificates' && (
+            <IssuerRefs
+              datasource={datasource}
+              resourceId="certificate.cert-manager.io"
+              namespace={namespace}
+              name={name}
+              title="Certificates"
+            />
+          )}
+          {activeTab === 'issuerref-certificaterequests' && (
+            <IssuerRefs
+              datasource={datasource}
+              resourceId="certificaterequest.cert-manager.io"
+              namespace={namespace}
+              name={name}
+              title="CertificateRequests"
+            />
+          )}
+          {activeTab === 'issuerref-orders' && (
+            <IssuerRefs
+              datasource={datasource}
+              resourceId="order.acme.cert-manager.io"
+              namespace={namespace}
+              name={name}
+              title="Orders"
+            />
+          )}
+          {activeTab === 'issuerref-challenges' && (
+            <IssuerRefs
+              datasource={datasource}
+              resourceId="challenge.acme.cert-manager.io"
+              namespace={namespace}
+              name={name}
+              title="Challenges"
             />
           )}
 

--- a/src/datasource/components/certmanager/IssuerRefs.tsx
+++ b/src/datasource/components/certmanager/IssuerRefs.tsx
@@ -11,11 +11,19 @@ import datasourcePluginJson from '../../../datasource/plugin.json';
 
 interface Props {
   datasource?: string;
+  resourceId: string;
   namespace?: string;
   name?: string;
+  title: string;
 }
 
-export function CertificateRequests({ datasource, namespace, name }: Props) {
+export function IssuerRefs({
+  datasource,
+  resourceId,
+  namespace,
+  name,
+  title,
+}: Props) {
   const queryRunner = new SceneQueryRunner({
     datasource: {
       type: datasourcePluginJson.id,
@@ -25,10 +33,10 @@ export function CertificateRequests({ datasource, namespace, name }: Props) {
       {
         refId: 'A',
         queryType: 'kubernetes-resources',
-        resourceId: 'certificaterequest.cert-manager.io',
-        namespace: namespace,
+        resourceId: resourceId,
+        namespace: namespace || '*',
         parameterName: 'jsonPath',
-        parameterValue: `{.items[?(@.metadata.annotations.cert-manager\\.io/certificate-name=='${name}')]}`,
+        parameterValue: `{.items[?(@.spec.issuerRef.name=='${name}')]}`,
       },
     ],
   });
@@ -38,7 +46,7 @@ export function CertificateRequests({ datasource, namespace, name }: Props) {
     body: new SceneFlexLayout({
       children: [
         new SceneFlexItem({
-          body: PanelBuilders.table().setTitle('CertificateRequests').build(),
+          body: PanelBuilders.table().setTitle(title).build(),
         }),
       ],
     }),

--- a/src/datasource/components/certmanager/Overview.tsx
+++ b/src/datasource/components/certmanager/Overview.tsx
@@ -8,6 +8,7 @@ import { Metadata } from '../shared/details/Metadata';
 import { Certificate } from './overview/Certificate';
 import { CertificateRequest } from './overview/CertificateRequest';
 import { Order } from './overview/Order';
+import { Challenge } from './overview/Challenge';
 
 interface Props {
   datasource?: string;
@@ -49,6 +50,9 @@ export function Overview({
         )}
         {manifest && resourceId === 'order.acme.cert-manager.io' && (
           <Order manifest={manifest} />
+        )}
+        {manifest && resourceId === 'challenge.acme.cert-manager.io' && (
+          <Challenge manifest={manifest} />
         )}
       </DefinitionLists>
     </ScrollContainer>

--- a/src/datasource/components/certmanager/overview/Challenge.tsx
+++ b/src/datasource/components/certmanager/overview/Challenge.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { Badge, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import {
+  DefinitionList,
+  DefinitionItem,
+} from '../../shared/definitionlist/DefinitionList';
+import { Resources } from '../../shared/details/Resources';
+import { KubernetesManifest } from '../../../types/kubernetes';
+
+interface Props {
+  datasource?: string;
+  namespace?: string;
+  manifest: KubernetesManifest;
+}
+
+export function Challenge({ datasource, namespace, manifest }: Props) {
+  const styles = useStyles2(() => {
+    return {
+      badge: css({
+        cursor: 'pointer',
+      }),
+    };
+  });
+
+  const [selectedIssuer, setSelectedIssuer] = useState<
+    { kind: string; name: string } | undefined
+  >(undefined);
+
+  return (
+    <>
+      <DefinitionList title="Details">
+        {manifest?.spec?.dnsNames && (
+          <DefinitionItem label="DNS Names">
+            {manifest?.spec?.dnsNames.map((dnsName: string) => (
+              <Badge key={dnsName} color="darkgrey" text={dnsName} />
+            ))}
+          </DefinitionItem>
+        )}
+        <DefinitionItem label={manifest.spec?.issuerRef?.kind || 'Issuer'}>
+          {manifest.spec?.issuerRef?.name ? (
+            <Badge
+              className={styles.badge}
+              color="blue"
+              onClick={() => setSelectedIssuer(manifest.spec.issuerRef)}
+              text={manifest.spec.issuerRef.name}
+            />
+          ) : (
+            '-'
+          )}
+        </DefinitionItem>
+
+        {selectedIssuer && (
+          <Resources
+            title={selectedIssuer.kind}
+            datasource={datasource}
+            resourceId={
+              selectedIssuer.kind === 'ClusterIssuer'
+                ? 'clusterissuer.cert-manager.io'
+                : 'issuer.cert-manager.io'
+            }
+            namespace={
+              selectedIssuer.kind === 'ClusterIssuer' ? undefined : namespace
+            }
+            parameterName="fieldSelector"
+            parameterValue={`metadata.name=${selectedIssuer.name}`}
+            onClose={() => setSelectedIssuer(undefined)}
+          />
+        )}
+      </DefinitionList>
+
+      <DefinitionList title="Status">
+        <DefinitionItem label="State">
+          {manifest.status && manifest.status?.state
+            ? manifest.status.state
+            : '-'}
+        </DefinitionItem>
+      </DefinitionList>
+    </>
+  );
+}


### PR DESCRIPTION
In the details drawer for cert-manager resources, we now show related
resources. The resources are selected using a JSONPath filter.

For Issuers and ClusterIssuers, we show the Certificates,
CertificateRequests, Orders and Challenges. For Challenges a custom
overview component is used to show the issuer reference.
