### PR TITLE
Extend Options for kubernetes Resources in Variable Query Editor

### DIFF
--- a/src/datasource/components/variablequeryeditor/KubernetesResources.tsx
+++ b/src/datasource/components/variablequeryeditor/KubernetesResources.tsx
@@ -1,6 +1,12 @@
 import React, { ChangeEvent } from 'react';
 import { QueryEditorProps } from '@grafana/data';
-import { InlineFieldRow, InlineField, Input } from '@grafana/ui';
+import {
+  InlineFieldRow,
+  InlineField,
+  Input,
+  InlineSwitch,
+  RadioButtonGroup,
+} from '@grafana/ui';
 
 import { DataSource } from '../../datasource';
 import { Query } from '../../types/query';
@@ -29,6 +35,52 @@ export function KubernetesResources({ datasource, query, onChange }: Props) {
             onChange({ ...query, namespace: value });
           }}
         />
+        <InlineField label="Wide">
+          <InlineSwitch
+            value={query.wide || false}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+              onChange({ ...query, wide: event.target.checked });
+            }}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label="Selector">
+          <RadioButtonGroup<string>
+            options={[
+              { label: 'None', value: '' },
+              { label: 'Label', value: 'labelSelector' },
+              { label: 'Field', value: 'fieldSelector' },
+              { label: 'JSONPath', value: 'jsonPath' },
+            ]}
+            value={query.parameterName || ''}
+            onChange={(value: string) => {
+              onChange({
+                ...query,
+                parameterName: value,
+                parameterValue: value === '' ? '' : query.parameterValue,
+              });
+            }}
+          />
+        </InlineField>
+        <InlineField
+          label="Value"
+          grow={true}
+          disabled={
+            query.parameterName !== 'labelSelector' &&
+            query.parameterName !== 'fieldSelector' &&
+            query.parameterName !== 'jsonPath'
+          }
+        >
+          <Input
+            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+              onChange({ ...query, parameterValue: event.target.value });
+            }}
+            value={query.parameterValue || ''}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
         <InlineField label="Field" grow={true}>
           <Input
             onChange={(event: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
In the variable query editor we only provided the resource and namespace
options for the "Kubernetes: Resources" query type. This commit adds all
other options which are also available via the query editor for the
"Kubernetes: Resources" query type.

Use case: User can select a deployment in a variable, the value of this
variable can then be used to get the `Selector` of this deployment by
enabling the wide option and using a field selector with the name of the
selected deployment. This selector can then be used to get all pods
which are part of the deployment.
