### PR TITLE
Add Regular Expression Filter

### DIFF
--- a/src/datasource/components/queryeditor/KubernetesResources.tsx
+++ b/src/datasource/components/queryeditor/KubernetesResources.tsx
@@ -59,6 +59,7 @@ export function KubernetesResources({
               { label: 'Label', value: 'labelSelector' },
               { label: 'Field', value: 'fieldSelector' },
               { label: 'JSONPath', value: 'jsonPath' },
+              { label: 'Regex', value: 'regex' },
             ]}
             value={query.parameterName || ''}
             onChange={(value: string) => {
@@ -77,7 +78,8 @@ export function KubernetesResources({
           disabled={
             query.parameterName !== 'labelSelector' &&
             query.parameterName !== 'fieldSelector' &&
-            query.parameterName !== 'jsonPath'
+            query.parameterName !== 'jsonPath' &&
+            query.parameterName !== 'regex'
           }
         >
           <Input


### PR DESCRIPTION
Add a new regex filter option to filter Kubernetes resources via regular
expressions, which are matching the name of a resource. This is done be
cause the JSONPath library does not support regular expressions (see
https://kubernetes.io/docs/reference/kubectl/jsonpath/#regular-expressions-in-jsonpath)
and it could be useful to have this, so that a variable in Grafana can
be used to filter resources by name.

For example if we get the names of all pods for a deployment via the
following PromQL query:

```
sum(kube_pod_owner) by (pod, owner_name) and on (owner_name) label_replace(kube_replicaset_owner{owner_kind="Deployment", namespace="$namespace", owner_name="$deployment", replicaset=~"$replicaset"}, "owner_name", "$1", "replicaset", "(.+)")
```

The returned list of pods can then be used to also get the pods via the
Kubernetes plugin (`${pods:regex}`).
