### PR TITLE
Show Jobs in CronJob Details

### DIFF
--- a/src/datasource/components/kubernetes/Details.tsx
+++ b/src/datasource/components/kubernetes/Details.tsx
@@ -30,6 +30,7 @@ import { Overview } from './Overview';
 import { Pods } from './Pods';
 import { Top } from './Top';
 import { AI } from './AI';
+import { Jobs } from './Jobs';
 
 initPluginTranslations('ricoberger-kubernetes-app');
 
@@ -120,6 +121,16 @@ export function Details({
                   }}
                 />
               )}
+            {['cronjob.batch'].includes(resourceId || '') && (
+              <Tab
+                label="Jobs"
+                active={activeTab === 'jobs'}
+                onChangeTab={(ev) => {
+                  ev?.preventDefault();
+                  setActiveTab('jobs');
+                }}
+              />
+            )}
             {[
               'daemonset.apps',
               'deployment.apps',
@@ -206,6 +217,9 @@ export function Details({
               namespace={namespace}
               manifest={state.value}
             />
+          )}
+          {activeTab === 'jobs' && (
+            <Jobs datasource={datasource} namespace={namespace} name={name} />
           )}
           {activeTab === 'top' && (
             <Top

--- a/src/datasource/components/kubernetes/Jobs.tsx
+++ b/src/datasource/components/kubernetes/Jobs.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {
+  EmbeddedScene,
+  PanelBuilders,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneQueryRunner,
+} from '@grafana/scenes';
+
+import datasourcePluginJson from '../../../datasource/plugin.json';
+
+interface Props {
+  datasource?: string;
+  namespace?: string;
+  name?: string;
+}
+
+export function Jobs({ datasource, namespace, name }: Props) {
+  const queryRunner = new SceneQueryRunner({
+    datasource: {
+      type: datasourcePluginJson.id,
+      uid: datasource || undefined,
+    },
+    queries: [
+      {
+        refId: 'A',
+        queryType: 'kubernetes-resources',
+        resourceId: 'job.batch',
+        namespace: namespace,
+        parameterName: 'jsonPath',
+        parameterValue: `{.items[?(@.metadata.ownerReferences[0].name=='${name}')]}`,
+      },
+    ],
+  });
+
+  const scene = new EmbeddedScene({
+    $data: queryRunner,
+    body: new SceneFlexLayout({
+      children: [
+        new SceneFlexItem({
+          body: PanelBuilders.table().setTitle('Jobs').build(),
+        }),
+      ],
+    }),
+  });
+
+  return <scene.Component model={scene} />;
+}


### PR DESCRIPTION
Show a list of Jobs in the details view of a CronJob. This allows user
to quickly see the Jobs that have been created by the CronJob and their
status without having to navigate to the Jobs list view.

The Jobs are selected via the following JSONPath filter:

```
{.items[?(@.metadata.ownerReferences[0].name=='mycronjob')]}
```
