### PR TITLE
Fix Panic when Invalid JSONPath is Provided

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -319,21 +319,23 @@ func (c *client) getResourcesByJSONPath(ctx context.Context, user string, groups
 	var found []NamespacedName
 	for _, result := range results {
 		for _, r := range result {
-			if metadata, ok := r.Interface().(map[string]any)["metadata"].(map[string]any); ok {
-				var namespace string
-				var name string
+			if item, ok := r.Interface().(map[string]any); ok {
+				if metadata, ok := item["metadata"].(map[string]any); ok {
+					var namespace string
+					var name string
 
-				if ns, ok := metadata["namespace"].(string); ok {
-					namespace = ns
-				}
-				if n, ok := metadata["name"].(string); ok {
-					name = n
-				}
+					if ns, ok := metadata["namespace"].(string); ok {
+						namespace = ns
+					}
+					if n, ok := metadata["name"].(string); ok {
+						name = n
+					}
 
-				found = append(found, NamespacedName{
-					Namespace: namespace,
-					Name:      name,
-				})
+					found = append(found, NamespacedName{
+						Namespace: namespace,
+						Name:      name,
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When an invalid JSONPath was provided by the user, the plugin crashed
with a panic, because we could not convert the result of the JSONPath
evaluation to the correct type. This commit adds a check to ensure that
the result of the JSONPath evaluation is of the expected type before
attempting to use it, so that the plugin does not crash.
