### PR TITLE
Add Docker Image for Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,3 +236,70 @@ jobs:
             }}-${{github.run_id}}-server-log
           path: grafana-server.log
           retention-days: 5
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Frontend
+        run: npm run build
+
+      - name: Build Backend
+        uses: magefile/mage-action@v3
+        with:
+          version: latest
+          args: buildAll
+
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{raw}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: ./utils/Dockerfile
+          platforms: linux/amd64,linux/arm
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/utils/Dockerfile
+++ b/utils/Dockerfile
@@ -1,0 +1,21 @@
+# This Dockerfile is used to serve the plugin archive via a simple HTTP server,
+# so that builds can be tested before an official release is made. It uses
+# BusyBox's httpd, which is a lightweight web server.
+#
+# Before the docker image can be build, the plugin archive must be created, by
+# running the following commands:
+# - npm run build
+# - mage -v
+# - cp -r dist ricoberger-kubernetes-app
+# - zip -qr ricoberger-kubernetes-app.zip ricoberger-kubernetes-app
+# - rm -rf ricoberger-kubernetes-app
+
+FROM busybox:1.37.0
+
+RUN adduser -D static
+USER static
+WORKDIR /home/static
+
+COPY ricoberger-kubernetes-app.zip .
+
+CMD ["busybox", "httpd", "-f", "-v", "-p", "8080"]


### PR DESCRIPTION
Add a Docker image, which is build on every push to the `main` branch
and contains the zip archive of the plugin. The archive is then served
by the Docker image on port 8080. The Grafana configuration can then be
adjusted to use this file as source for the plugin.

This allows us to test the plugin in a more realistic environment,
without the need to create a new release.
