### PR TITLE
Adjust Field Name for Linked Traces

### DIFF
--- a/src/datasource/transformations/kubernetes.tsx
+++ b/src/datasource/transformations/kubernetes.tsx
@@ -57,7 +57,7 @@ export const kubernetesLogsTransformation = (
     fields: [
       ...frame.fields,
       {
-        name: 'traceID',
+        name: 'Trace',
         type: FieldType.string,
         values: labels.map((labels) => {
           for (const [key, value] of Object.entries(labels)) {
@@ -73,7 +73,7 @@ export const kubernetesLogsTransformation = (
         config: {
           links: [
             {
-              title: 'Trace',
+              title: 'View Trace',
               url: `/explore?left=${tracesQuery}`,
               targetBlank: true,
             },


### PR DESCRIPTION
If the configuration contains a trace query (`integrationsTracesQuery`)
we show a link to the trace in the logs view. The corresponding field
name was `traceId`, which didn't looked nice in the UI, so that this is
now named `Trace`.
