### PR TITLE
Add Refresh Option to Query Variables

### DIFF
--- a/src/components/certmanager/CertManagerPage.tsx
+++ b/src/components/certmanager/CertManagerPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GrafanaTheme2, VariableSort } from '@grafana/data';
+import { GrafanaTheme2, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -65,6 +65,7 @@ export const CertManagerPage = () => {
           name="datasource"
           label="Cluster"
           pluginId={datasourcePluginJson.id}
+          refresh={VariableRefresh.onDashboardLoad}
         >
           <CustomVariable
             name="resourceId"
@@ -83,6 +84,7 @@ export const CertManagerPage = () => {
                 refId: 'kubernetes-namespaces',
                 queryType: 'kubernetes-namespaces',
               }}
+              refresh={VariableRefresh.onDashboardLoad}
               sort={VariableSort.alphabeticalCaseInsensitiveAsc}
               initialValue={DEFAULT_QUERIES['kubernetes-resources'].namespace}
             >

--- a/src/components/flux/FluxPage.tsx
+++ b/src/components/flux/FluxPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GrafanaTheme2, VariableSort } from '@grafana/data';
+import { GrafanaTheme2, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -61,6 +61,7 @@ export const FluxPage = () => {
           name="datasource"
           label="Cluster"
           pluginId={datasourcePluginJson.id}
+          refresh={VariableRefresh.onDashboardLoad}
         >
           <CustomVariable
             name="resourceId"
@@ -79,6 +80,7 @@ export const FluxPage = () => {
                 refId: 'kubernetes-namespaces',
                 queryType: 'kubernetes-namespaces',
               }}
+              refresh={VariableRefresh.onDashboardLoad}
               sort={VariableSort.alphabeticalCaseInsensitiveAsc}
               initialValue={DEFAULT_QUERIES['kubernetes-resources'].namespace}
             >

--- a/src/components/helm/HelmPage.tsx
+++ b/src/components/helm/HelmPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GrafanaTheme2, VariableSort } from '@grafana/data';
+import { GrafanaTheme2, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -60,6 +60,7 @@ export const HelmPage = () => {
           name="datasource"
           label="Cluster"
           pluginId={datasourcePluginJson.id}
+          refresh={VariableRefresh.onDashboardLoad}
         >
           <QueryVariable
             name="namespace"
@@ -72,6 +73,7 @@ export const HelmPage = () => {
               refId: 'kubernetes-namespaces',
               queryType: 'kubernetes-namespaces',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             sort={VariableSort.alphabeticalCaseInsensitiveAsc}
             initialValue={DEFAULT_QUERIES['helm-releases'].namespace}
           >

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VariableHide, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Card, Stack, useStyles2 } from '@grafana/ui';
 import {
@@ -81,6 +81,7 @@ export function HomePage() {
         name="datasource"
         label="Cluster"
         pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
       >
         <QueryVariable
           name="prometheus"
@@ -92,6 +93,7 @@ export function HomePage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -104,6 +106,7 @@ export function HomePage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <QueryVariable
@@ -117,6 +120,7 @@ export function HomePage() {
                 refId: 'namespaces',
                 query: variableQuery(queries.namespaces.labelsByCluster),
               }}
+              refresh={VariableRefresh.onTimeRangeChanged}
               isMulti={true}
               includeAll={true}
               initialValue={'$__all'}

--- a/src/components/metrics/MetricsPage.tsx
+++ b/src/components/metrics/MetricsPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VariableHide, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import {
@@ -31,6 +31,7 @@ export function MetricsPage() {
         name="datasource"
         label="Cluster"
         pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
       >
         <QueryVariable
           name="prometheus"
@@ -42,6 +43,7 @@ export function MetricsPage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -54,6 +56,7 @@ export function MetricsPage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <QueryVariable
@@ -67,6 +70,7 @@ export function MetricsPage() {
                 refId: 'namespaces',
                 query: variableQuery(queries.namespaces.labelsByCluster),
               }}
+              refresh={VariableRefresh.onTimeRangeChanged}
               isMulti={true}
               includeAll={true}
               initialValue={'$__all'}

--- a/src/components/metrics/namespaces/NamespacePage.tsx
+++ b/src/components/metrics/namespaces/NamespacePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { VariableHide, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Alert, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import {
@@ -37,6 +37,7 @@ export function NamespacePage() {
         name="datasource"
         label="Cluster"
         pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
         hide={VariableHide.hideVariable}
       >
         <QueryVariable
@@ -49,6 +50,7 @@ export function NamespacePage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -61,6 +63,7 @@ export function NamespacePage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <CustomVariable
@@ -83,6 +86,7 @@ export function NamespacePage() {
                     queries.workloads.labelsByClusterNamespace,
                   ),
                 }}
+                refresh={VariableRefresh.onTimeRangeChanged}
                 isMulti={true}
                 includeAll={true}
                 initialValue={'$__all'}

--- a/src/components/metrics/namespaces/NamespacesPage.tsx
+++ b/src/components/metrics/namespaces/NamespacesPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VariableHide, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import {
@@ -31,6 +31,7 @@ export function NamespacesPage() {
         name="datasource"
         label="Cluster"
         pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
       >
         <QueryVariable
           name="prometheus"
@@ -42,6 +43,7 @@ export function NamespacesPage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -54,6 +56,7 @@ export function NamespacesPage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <QueryVariable
@@ -67,6 +70,7 @@ export function NamespacesPage() {
                 refId: 'namespaces',
                 query: variableQuery(queries.namespaces.labelsByCluster),
               }}
+              refresh={VariableRefresh.onTimeRangeChanged}
               isMulti={true}
               includeAll={true}
               initialValue={'$__all'}

--- a/src/components/metrics/nodes/NodePage.tsx
+++ b/src/components/metrics/nodes/NodePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { VariableHide, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Alert, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import {
@@ -37,6 +37,7 @@ export function NodePage() {
         name="datasource"
         label="Cluster"
         pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
         hide={VariableHide.hideVariable}
       >
         <QueryVariable
@@ -49,6 +50,7 @@ export function NodePage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -61,6 +63,7 @@ export function NodePage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <CustomVariable
@@ -88,6 +91,7 @@ export function NodePage() {
                     refId: 'pods',
                     query: variableQuery(queries.pods.labelsByClusterNode),
                   }}
+                  refresh={VariableRefresh.onTimeRangeChanged}
                   isMulti={true}
                   includeAll={true}
                   initialValue={'$__all'}

--- a/src/components/metrics/nodes/NodesPage.tsx
+++ b/src/components/metrics/nodes/NodesPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VariableHide } from '@grafana/data';
+import { VariableHide, VariableRefresh } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import {
@@ -31,6 +31,7 @@ export function NodesPage() {
         name="datasource"
         label="Cluster"
         pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
       >
         <QueryVariable
           name="prometheus"
@@ -42,6 +43,7 @@ export function NodesPage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -54,6 +56,7 @@ export function NodesPage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <PluginPage

--- a/src/components/metrics/pods/PodPage.tsx
+++ b/src/components/metrics/pods/PodPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { VariableHide } from '@grafana/data';
+import { VariableHide, VariableRefresh } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Alert, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import {
@@ -40,6 +40,7 @@ export function PodPage() {
         name="datasource"
         label="Cluster"
         pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
         hide={VariableHide.hideVariable}
       >
         <QueryVariable
@@ -52,6 +53,7 @@ export function PodPage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -64,6 +66,7 @@ export function PodPage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <CustomVariable

--- a/src/components/metrics/pods/PodsPage.tsx
+++ b/src/components/metrics/pods/PodsPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VariableHide, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import {
@@ -32,6 +32,7 @@ export function PodsPage() {
         name="datasource"
         label="Cluster"
         pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
       >
         <QueryVariable
           name="prometheus"
@@ -43,6 +44,7 @@ export function PodsPage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -55,6 +57,7 @@ export function PodsPage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <CustomVariable
@@ -74,6 +77,7 @@ export function PodsPage() {
                   refId: 'namespaces',
                   query: variableQuery(queries.namespaces.labelsByCluster),
                 }}
+                refresh={VariableRefresh.onTimeRangeChanged}
                 isMulti={true}
                 includeAll={true}
                 initialValue={'$__all'}
@@ -91,6 +95,7 @@ export function PodsPage() {
                     refId: 'pods',
                     query: variableQuery(queries.pods.labelsByClusterNamespace),
                   }}
+                  refresh={VariableRefresh.onTimeRangeChanged}
                   isMulti={true}
                   includeAll={true}
                   initialValue={'$__all'}

--- a/src/components/metrics/workloads/WorkloadPage.tsx
+++ b/src/components/metrics/workloads/WorkloadPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { VariableHide, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Alert, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import {
@@ -50,6 +50,7 @@ export function WorkloadPage() {
         label="Cluster"
         pluginId={datasourcePluginJson.id}
         hide={VariableHide.hideVariable}
+        refresh={VariableRefresh.onDashboardLoad}
       >
         <QueryVariable
           name="prometheus"
@@ -61,6 +62,7 @@ export function WorkloadPage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -73,6 +75,7 @@ export function WorkloadPage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <CustomVariable
@@ -116,6 +119,7 @@ export function WorkloadPage() {
                           queries.pods.labelsByClusterNamespaceWorkload,
                         ),
                       }}
+                      refresh={VariableRefresh.onTimeRangeChanged}
                       isMulti={true}
                       includeAll={true}
                       initialValue={'$__all'}

--- a/src/components/metrics/workloads/WorkloadsPage.tsx
+++ b/src/components/metrics/workloads/WorkloadsPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VariableHide, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import {
@@ -31,6 +31,7 @@ export function WorkloadsPage() {
         name="datasource"
         label="Cluster"
         pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
       >
         <QueryVariable
           name="prometheus"
@@ -42,6 +43,7 @@ export function WorkloadsPage() {
             setting: 'integrationsMetricsDatasourceUid',
             variableField: 'values',
           }}
+          refresh={VariableRefresh.onDashboardLoad}
           hide={VariableHide.hideVariable}
         >
           <QueryVariable
@@ -54,6 +56,7 @@ export function WorkloadsPage() {
               setting: 'integrationsMetricsClusterLabel',
               variableField: 'values',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
             <QueryVariable
@@ -67,6 +70,7 @@ export function WorkloadsPage() {
                 refId: 'namespaces',
                 query: variableQuery(queries.namespaces.labelsByCluster),
               }}
+              refresh={VariableRefresh.onTimeRangeChanged}
               isMulti={true}
               includeAll={true}
               initialValue={'$__all'}
@@ -86,6 +90,7 @@ export function WorkloadsPage() {
                     queries.workloads.labelsByClusterNamespace,
                   ),
                 }}
+                refresh={VariableRefresh.onTimeRangeChanged}
                 isMulti={true}
                 includeAll={true}
                 initialValue={'$__all'}

--- a/src/components/resources/ResourcesPage.tsx
+++ b/src/components/resources/ResourcesPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GrafanaTheme2, VariableSort } from '@grafana/data';
+import { GrafanaTheme2, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -64,6 +64,7 @@ export const ResourcesPage = () => {
           name="datasource"
           label="Cluster"
           pluginId={datasourcePluginJson.id}
+          refresh={VariableRefresh.onDashboardLoad}
         >
           <QueryVariable
             name="resourceId"
@@ -73,6 +74,7 @@ export const ResourcesPage = () => {
               refId: 'kubernetes-resourceids',
               queryType: 'kubernetes-resourceids',
             }}
+            refresh={VariableRefresh.onDashboardLoad}
             sort={VariableSort.alphabeticalCaseInsensitiveAsc}
             initialValue={DEFAULT_QUERIES['kubernetes-resources'].resourceId}
           >
@@ -87,6 +89,7 @@ export const ResourcesPage = () => {
                 refId: 'kubernetes-namespaces',
                 queryType: 'kubernetes-namespaces',
               }}
+              refresh={VariableRefresh.onDashboardLoad}
               sort={VariableSort.alphabeticalCaseInsensitiveAsc}
               initialValue={DEFAULT_QUERIES['kubernetes-resources'].namespace}
             >


### PR DESCRIPTION
Add the refresh option to all query variables, so that they are
correctly refreshed on dashboard load or when the time range changes.
