### PR TITLE
Add CPU and Memory Details Metrics

### DIFF
--- a/src/components/certmanager/CertManagerPage.tsx
+++ b/src/components/certmanager/CertManagerPage.tsx
@@ -46,7 +46,7 @@ export const CertManagerPage = () => {
   return (
     <PluginPage
       renderTitle={() => (
-        <Stack gap={0}>
+        <Stack gap={0} alignItems="center" direction="row">
           <img
             className={styles.title.image}
             alt="cert-manager"

--- a/src/components/flux/FluxPage.tsx
+++ b/src/components/flux/FluxPage.tsx
@@ -46,7 +46,7 @@ export const FluxPage = () => {
   return (
     <PluginPage
       renderTitle={() => (
-        <Stack gap={0}>
+        <Stack gap={0} alignItems="center" direction="row">
           <img className={styles.title.image} alt="Flux" src={fluxImg} />
           <h1>Flux</h1>
         </Stack>

--- a/src/components/helm/HelmPage.tsx
+++ b/src/components/helm/HelmPage.tsx
@@ -45,7 +45,7 @@ export const HelmPage = () => {
   return (
     <PluginPage
       renderTitle={() => (
-        <Stack gap={0}>
+        <Stack gap={0} alignItems="center" direction="row">
           <img className={styles.title.image} alt="Helm" src={helmImg} />
           <h1>Helm</h1>
         </Stack>

--- a/src/components/kubeconfig/KubeconfigPage.tsx
+++ b/src/components/kubeconfig/KubeconfigPage.tsx
@@ -39,7 +39,7 @@ export const KubeconfigPage = () => {
   return (
     <PluginPage
       renderTitle={() => (
-        <Stack gap={0}>
+        <Stack gap={0} alignItems="center" direction="row">
           <img
             className={styles.title.image}
             alt="Kubeconfig"

--- a/src/components/kubectl/KubectlPage.tsx
+++ b/src/components/kubectl/KubectlPage.tsx
@@ -47,7 +47,7 @@ export const KubectlPage = () => {
   return (
     <PluginPage
       renderTitle={() => (
-        <Stack gap={0}>
+        <Stack gap={0} alignItems="center" direction="row">
           <img
             className={styles.title.image}
             alt="kubectl"

--- a/src/components/metrics/MetricsPage.tsx
+++ b/src/components/metrics/MetricsPage.tsx
@@ -79,7 +79,7 @@ export function MetricsPage() {
             >
               <PluginPage
                 renderTitle={() => (
-                  <Stack gap={0}>
+                  <Stack gap={0} alignItems="center" direction="row">
                     <img
                       className={styles.pluginPage.title.image}
                       alt="Metrics"

--- a/src/components/metrics/namespaces/NamespacePage.tsx
+++ b/src/components/metrics/namespaces/NamespacePage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
-import { Alert, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
+import { Alert, Badge, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import {
   SceneContextProvider,
   DataSourceVariable,
@@ -18,6 +18,8 @@ import { getStyles } from '../../../utils/utils.styles';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { queries, variableQuery } from '../queries';
 import { NamespacePageOverview } from './NamespacePageOverview';
+import { NamespacePageCPU } from './NamespacePageCPU';
+import { NamespacePageMemory } from './NamespacePageMemory';
 
 export function NamespacePage() {
   const styles = useStyles2(getStyles);
@@ -96,13 +98,18 @@ export function NamespacePage() {
               >
                 <PluginPage
                   renderTitle={() => (
-                    <Stack gap={0}>
+                    <Stack gap={0} alignItems="center" direction="row">
                       <img
                         className={styles.pluginPage.title.image}
                         alt={namespace}
                         src={resourcesImg}
                       />
                       <h1>{namespace}</h1>
+                      <Badge
+                        className={styles.pluginPage.title.badge}
+                        color="blue"
+                        text="namespace"
+                      />
                     </Stack>
                   )}
                   subTitle={pluginJson.info.description}
@@ -156,6 +163,8 @@ export function NamespacePage() {
                     />
                   </TabsBar>
                   {activeTab === 'overview' && <NamespacePageOverview />}
+                  {activeTab === 'cpu' && <NamespacePageCPU />}
+                  {activeTab === 'memory' && <NamespacePageMemory />}
                 </PluginPage>
               </QueryVariable>
             </CustomVariable>

--- a/src/components/metrics/namespaces/NamespacePageCPU.tsx
+++ b/src/components/metrics/namespaces/NamespacePageCPU.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+import { TimeSeriesMemoryOrCPUEfficiency } from '../shared/TimeSeriesMemoryOrCPUEfficiency';
+import { TableMemoryOrCPUUsage } from '../shared/TableMemoryOrCPUUsage';
+
+export function NamespacePageCPU() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="namespace" />
+        <VariableControl name="workload" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPU
+          title="Overview: Usage"
+          unit="cores"
+          allocationExpr={queries.namespaces.cpuAllocation}
+          limitsExpr={queries.namespaces.cpuLimits}
+          requestsExpr={queries.namespaces.cpuRequests}
+          usageExpr={queries.namespaces.cpuUsage}
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Distribution: Workload Usage"
+          unit="cores"
+          expr={queries.workloads.cpuDistribution}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+        <TimeSeriesMemoryOrCPUEfficiency
+          title="Efficiency: Workload Usage / Requests"
+          unit="percentunit"
+          expr={queries.workloads.cpuEfficiency}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Workload Waiting"
+          unit="s"
+          expr={queries.workloads.cpuPressureWaiting}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Workload Stalled"
+          unit="s"
+          expr={queries.workloads.cpuPressureStalled}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TableMemoryOrCPUUsage
+          title="Workloads"
+          unit="cores"
+          infoExpr={queries.workloads.infoJoinKey}
+          usageExpr={queries.workloads.cpuUsageJoinKey}
+          requestsExpr={queries.workloads.cpuRequestsJoinKey}
+          requestsPercentExpr={queries.workloads.cpuRequestsPercentJoinKey}
+          limitsExpr={queries.workloads.cpuLimitsJoinKey}
+          limitsPercentExpr={queries.workloads.cpuLimitsPercentJoinKey}
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/namespaces/NamespacePageMemory.tsx
+++ b/src/components/metrics/namespaces/NamespacePageMemory.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+import { TimeSeriesMemoryOrCPUEfficiency } from '../shared/TimeSeriesMemoryOrCPUEfficiency';
+import { TableMemoryOrCPUUsage } from '../shared/TableMemoryOrCPUUsage';
+
+export function NamespacePageMemory() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="namespace" />
+        <VariableControl name="workload" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPU
+          title="Overview: Usage"
+          unit="bytes"
+          allocationExpr={queries.namespaces.memoryAllocation}
+          limitsExpr={queries.namespaces.memoryLimits}
+          requestsExpr={queries.namespaces.memoryRequests}
+          usageExpr={queries.namespaces.memoryUsage}
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Distribution: Workload Usage"
+          unit="bytes"
+          expr={queries.workloads.memoryDistribution}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+        <TimeSeriesMemoryOrCPUEfficiency
+          title="Efficiency: Workload Usage / Requests"
+          unit="percentunit"
+          expr={queries.workloads.memoryEfficiency}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Workload Waiting"
+          unit="s"
+          expr={queries.workloads.memoryPressureWaiting}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Workload Stalled"
+          unit="s"
+          expr={queries.workloads.memoryPressureStalled}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TableMemoryOrCPUUsage
+          title="Workloads"
+          unit="bytes"
+          infoExpr={queries.workloads.infoJoinKey}
+          usageExpr={queries.workloads.memoryUsageJoinKey}
+          requestsExpr={queries.workloads.memoryRequestsJoinKey}
+          requestsPercentExpr={queries.workloads.memoryRequestsPercentJoinKey}
+          limitsExpr={queries.workloads.memoryLimitsJoinKey}
+          limitsPercentExpr={queries.workloads.memoryLimitsPercentJoinKey}
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/namespaces/NamespacesPage.tsx
+++ b/src/components/metrics/namespaces/NamespacesPage.tsx
@@ -79,7 +79,7 @@ export function NamespacesPage() {
             >
               <PluginPage
                 renderTitle={() => (
-                  <Stack gap={0}>
+                  <Stack gap={0} alignItems="center" direction="row">
                     <img
                       className={styles.pluginPage.title.image}
                       alt="Namespaces"

--- a/src/components/metrics/nodes/NodePage.tsx
+++ b/src/components/metrics/nodes/NodePage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
-import { Alert, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
+import { Alert, Badge, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import {
   SceneContextProvider,
   DataSourceVariable,
@@ -18,6 +18,8 @@ import { getStyles } from '../../../utils/utils.styles';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { queries, variableQuery } from '../queries';
 import { NodePageOverview } from './NodePageOverview';
+import { NodePageCPU } from './NodePageCPU';
+import { NodePageMemory } from './NodePageMemory';
 
 export function NodePage() {
   const styles = useStyles2(getStyles);
@@ -99,13 +101,18 @@ export function NodePage() {
                 >
                   <PluginPage
                     renderTitle={() => (
-                      <Stack gap={0}>
+                      <Stack gap={0} alignItems="center" direction="row">
                         <img
                           className={styles.pluginPage.title.image}
                           alt={node}
                           src={resourcesImg}
                         />
                         <h1>{node}</h1>
+                        <Badge
+                          className={styles.pluginPage.title.badge}
+                          color="blue"
+                          text="node"
+                        />
                       </Stack>
                     )}
                     subTitle={pluginJson.info.description}
@@ -159,6 +166,8 @@ export function NodePage() {
                       />
                     </TabsBar>
                     {activeTab === 'overview' && <NodePageOverview />}
+                    {activeTab === 'cpu' && <NodePageCPU />}
+                    {activeTab === 'memory' && <NodePageMemory />}
                   </PluginPage>
                 </QueryVariable>
               </CustomVariable>

--- a/src/components/metrics/nodes/NodePageCPU.tsx
+++ b/src/components/metrics/nodes/NodePageCPU.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+import { TimeSeriesMemoryOrCPUEfficiency } from '../shared/TimeSeriesMemoryOrCPUEfficiency';
+import { TableMemoryOrCPUUsage } from '../shared/TableMemoryOrCPUUsage';
+
+export function NodePageCPU() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="node" />
+        <VariableControl name="namespace" />
+        <VariableControl name="pod" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPU
+          title="Overview: Usage"
+          unit="cores"
+          capacityExpr={queries.nodes.cpuCapacity}
+          limitsExpr={queries.nodes.cpuLimits}
+          requestsExpr={queries.nodes.cpuRequests}
+          usageExpr={queries.nodes.cpuUsage}
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Distribution: Pod Usage / Node Capacity"
+          unit="percentunit"
+          expr={queries.nodes.cpuDistribution}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUEfficiency
+          title="Efficiency: Pod Usage / Requests"
+          unit="percentunit"
+          expr={queries.nodes.cpuEfficiency}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Waiting"
+          unit="s"
+          expr={queries.pods.cpuPressureWaiting}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Stalled"
+          unit="s"
+          expr={queries.pods.cpuPressureStalled}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TableMemoryOrCPUUsage
+          title="Pods"
+          unit="cores"
+          infoExpr={queries.pods.infoJoinKey}
+          usageExpr={queries.pods.cpuUsageJoinKey}
+          requestsExpr={queries.pods.cpuRequestsJoinKey}
+          requestsPercentExpr={queries.pods.cpuRequestsPercentJoinKey}
+          limitsExpr={queries.pods.cpuLimitsJoinKey}
+          limitsPercentExpr={queries.pods.cpuLimitsPercentJoinKey}
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/nodes/NodePageMemory.tsx
+++ b/src/components/metrics/nodes/NodePageMemory.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+import { TimeSeriesMemoryOrCPUEfficiency } from '../shared/TimeSeriesMemoryOrCPUEfficiency';
+import { TableMemoryOrCPUUsage } from '../shared/TableMemoryOrCPUUsage';
+
+export function NodePageMemory() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="node" />
+        <VariableControl name="namespace" />
+        <VariableControl name="pod" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPU
+          title="Overview: Usage"
+          unit="bytes"
+          capacityExpr={queries.nodes.memoryCapacity}
+          limitsExpr={queries.nodes.memoryLimits}
+          requestsExpr={queries.nodes.memoryRequests}
+          usageExpr={queries.nodes.memoryUsage}
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Distribution: Pod Usage / Node Capacity"
+          unit="percentunit"
+          expr={queries.nodes.memoryDistribution}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUEfficiency
+          title="Efficiency: Pod Usage / Requests"
+          unit="percentunit"
+          expr={queries.nodes.memoryEfficiency}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Waiting"
+          unit="s"
+          expr={queries.pods.memoryPressureWaiting}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Stalled"
+          unit="s"
+          expr={queries.pods.memoryPressureStalled}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TableMemoryOrCPUUsage
+          title="Pods"
+          unit="bytes"
+          infoExpr={queries.pods.infoJoinKey}
+          usageExpr={queries.pods.memoryUsageJoinKey}
+          requestsExpr={queries.pods.memoryRequestsJoinKey}
+          requestsPercentExpr={queries.pods.memoryRequestsPercentJoinKey}
+          limitsExpr={queries.pods.memoryLimitsJoinKey}
+          limitsPercentExpr={queries.pods.memoryLimitsPercentJoinKey}
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/nodes/NodesPage.tsx
+++ b/src/components/metrics/nodes/NodesPage.tsx
@@ -61,7 +61,7 @@ export function NodesPage() {
           >
             <PluginPage
               renderTitle={() => (
-                <Stack gap={0}>
+                <Stack gap={0} alignItems="center" direction="row">
                   <img
                     className={styles.pluginPage.title.image}
                     alt="Nodes"

--- a/src/components/metrics/pods/PodPage.tsx
+++ b/src/components/metrics/pods/PodPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { VariableHide, VariableRefresh } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
-import { Alert, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
+import { Alert, Badge, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import {
   SceneContextProvider,
   DataSourceVariable,
@@ -17,6 +17,8 @@ import resourcesImg from '../../../img/logo.svg';
 import { getStyles } from '../../../utils/utils.styles';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { PodPageOverview } from './PodPageOverview';
+import { PodPageCPU } from './PodPageCPU';
+import { PodPageMemory } from './PodPageMemory';
 
 export function PodPage() {
   const styles = useStyles2(getStyles);
@@ -85,13 +87,18 @@ export function PodPage() {
               >
                 <PluginPage
                   renderTitle={() => (
-                    <Stack gap={0}>
+                    <Stack gap={0} alignItems="center" direction="row">
                       <img
                         className={styles.pluginPage.title.image}
-                        alt={namespace}
+                        alt={pod}
                         src={resourcesImg}
                       />
-                      <h1>{namespace}</h1>
+                      <h1>{pod}</h1>
+                      <Badge
+                        className={styles.pluginPage.title.badge}
+                        color="blue"
+                        text="pod"
+                      />
                     </Stack>
                   )}
                   subTitle={pluginJson.info.description}
@@ -145,6 +152,8 @@ export function PodPage() {
                     />
                   </TabsBar>
                   {activeTab === 'overview' && <PodPageOverview />}
+                  {activeTab === 'cpu' && <PodPageCPU />}
+                  {activeTab === 'memory' && <PodPageMemory />}
                 </PluginPage>
               </CustomVariable>
             </CustomVariable>

--- a/src/components/metrics/pods/PodPageCPU.tsx
+++ b/src/components/metrics/pods/PodPageCPU.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+import { TimeSeriesMemoryOrCPUEfficiency } from '../shared/TimeSeriesMemoryOrCPUEfficiency';
+import { TableMemoryOrCPUUsage } from '../shared/TableMemoryOrCPUUsage';
+
+export function PodPageCPU() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="namespace" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPU
+          title="Overview Usage"
+          unit="cores"
+          allocationExpr={queries.pods.cpuAllocation}
+          limitsExpr={queries.pods.cpuLimits}
+          requestsExpr={queries.pods.cpuRequests}
+          usageExpr={queries.pods.cpuUsage}
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Distribution: Container Usage"
+          unit="cores"
+          expr={queries.containers.cpuDistribution}
+          legend="{{ container }}"
+        />
+        <TimeSeriesMemoryOrCPUEfficiency
+          title="Efficiency: Container Usage / Requests"
+          unit="percentunit"
+          expr={queries.containers.cpuEfficiency}
+          legend="{{ container }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Container Waiting"
+          unit="s"
+          expr={queries.containers.cpuPressureWaiting}
+          legend="{{ container }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Container Stalled"
+          unit="s"
+          expr={queries.containers.cpuPressureStalled}
+          legend="{{ container }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TableMemoryOrCPUUsage
+          title="Containers"
+          unit="cores"
+          infoContainerExpr={queries.containers.infoJoinKey}
+          usageExpr={queries.containers.cpuUsageJoinKey}
+          requestsExpr={queries.containers.cpuRequestsJoinKey}
+          requestsPercentExpr={queries.containers.cpuRequestsPercentJoinKey}
+          limitsExpr={queries.containers.cpuLimitsJoinKey}
+          limitsPercentExpr={queries.containers.cpuLimitsPercentJoinKey}
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/pods/PodPageMemory.tsx
+++ b/src/components/metrics/pods/PodPageMemory.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+import { TimeSeriesMemoryOrCPUEfficiency } from '../shared/TimeSeriesMemoryOrCPUEfficiency';
+import { TableMemoryOrCPUUsage } from '../shared/TableMemoryOrCPUUsage';
+
+export function PodPageMemory() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="namespace" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPU
+          title="Overview: Usage"
+          unit="bytes"
+          allocationExpr={queries.pods.memoryAllocation}
+          limitsExpr={queries.pods.memoryLimits}
+          requestsExpr={queries.pods.memoryRequests}
+          usageExpr={queries.pods.memoryUsage}
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Distribution: Container Usage"
+          unit="bytes"
+          expr={queries.containers.memoryDistribution}
+          legend="{{ container }}"
+        />
+        <TimeSeriesMemoryOrCPUEfficiency
+          title="Efficiency: Container Usage / Requests"
+          unit="percentunit"
+          expr={queries.containers.memoryEfficiency}
+          legend="{{ container }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Container Waiting"
+          unit="s"
+          expr={queries.containers.memoryPressureWaiting}
+          legend="{{ container }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Container Stalled"
+          unit="s"
+          expr={queries.containers.memoryPressureStalled}
+          legend="{{ container }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TableMemoryOrCPUUsage
+          title="Containers"
+          unit="bytes"
+          infoContainerExpr={queries.containers.infoJoinKey}
+          usageExpr={queries.containers.memoryUsageJoinKey}
+          requestsExpr={queries.containers.memoryRequestsJoinKey}
+          requestsPercentExpr={queries.containers.memoryRequestsPercentJoinKey}
+          limitsExpr={queries.containers.memoryLimitsJoinKey}
+          limitsPercentExpr={queries.containers.memoryLimitsPercentJoinKey}
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/pods/PodsPage.tsx
+++ b/src/components/metrics/pods/PodsPage.tsx
@@ -104,7 +104,7 @@ export function PodsPage() {
                 >
                   <PluginPage
                     renderTitle={() => (
-                      <Stack gap={0}>
+                      <Stack gap={0} alignItems="center" direction="row">
                         <img
                           className={styles.pluginPage.title.image}
                           alt="Pods"

--- a/src/components/metrics/queries.ts
+++ b/src/components/metrics/queries.ts
@@ -628,6 +628,100 @@ sum(
   ",",
   "instance"
 )`,
+    cpuDistribution: `(
+  sum(
+    max(
+      node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{
+        cluster=~"$cluster",
+        node=~"$node",
+        pod=~"$pod"
+      }
+    ) by(cluster,namespace,pod,container,node)
+  ) by(cluster,namespace,pod,node)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+)
+  / on(cluster,node) group_left()
+sum(
+  max(
+    kube_node_status_capacity{
+      cluster=~"$cluster",
+      resource=~"cpu",
+      node=~"$node"
+    }
+  ) by(cluster,node)
+) by(cluster,node)`,
+    cpuEfficiency: `sum(
+  max(
+    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,container,node)
+) by(cluster,namespace,pod,node)
+  /
+sum(
+  max(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,container,node)
+) by(cluster,namespace,pod,node)`,
+    memoryDistribution: `(
+  sum(
+    max(
+      node_namespace_pod_container:container_memory_working_set_bytes{
+        cluster=~"$cluster",
+        node=~"$node",
+        pod=~"$pod"
+      }
+    ) by(cluster,namespace,pod,container,node)
+  ) by(cluster,namespace,pod,node)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+)
+  / on(cluster,node) group_left()
+sum(
+  max(
+    kube_node_status_capacity{
+      cluster=~"$cluster",
+      resource=~"memory",
+      node=~"$node"
+    }
+  ) by(cluster,node)
+) by(cluster,node)`,
+    memoryEfficiency: `sum(
+  max(
+    node_namespace_pod_container:container_memory_working_set_bytes{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,container,node)
+) by(cluster,namespace,pod,node)
+  /
+sum(
+  max(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,container,node)
+) by(cluster,namespace,pod,node)`,
   },
   namespaces: {
     labelsByCluster: `label_values(kube_namespace_status_phase{cluster=~"$cluster"}, namespace)`,
@@ -2184,6 +2278,607 @@ sum(
     cluster=~"$cluster",namespace=~"$namespace",job_name=~"$workload"
   }
 )`,
+    cpuDistribution: `sum(
+  sum(
+    max(
+      node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    cpuEfficiency: `sum(
+  sum(
+    max(
+      node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)
+  / on(cluster,namespace,workload,workload_type) group_left()
+sum(
+  max(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      namespace=~"$namespace"
+    }
+  ) by(cluster,namespace,pod,container)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    memoryDistribution: `sum(
+  sum(
+    max(
+      node_namespace_pod_container:container_memory_working_set_bytes{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    memoryEfficiency: `sum(
+  sum(
+    max(
+      node_namespace_pod_container:container_memory_working_set_bytes{
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)
+  / on(cluster,namespace,workload,workload_type) group_left()
+sum(
+  max(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      namespace=~"$namespace"
+    }
+  ) by(cluster,namespace,pod,container)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    cpuPressureWaiting: `sum(
+  sum(
+    sum(
+      rate(
+        container_pressure_cpu_waiting_seconds_total{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          container!="",
+          container!="POD"
+        }[$__rate_interval]
+      )
+    ) by(cluster,namespace,pod)
+      >
+    0
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    cpuPressureStalled: `sum(
+  sum(
+    sum(
+      rate(
+        container_pressure_cpu_stalled_seconds_total{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          container!="",
+          container!="POD"
+        }[$__rate_interval]
+      )
+    ) by(cluster,namespace,pod)
+      >
+    0
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    memoryPressureWaiting: `sum(
+  sum(
+    sum(
+      rate(
+        container_pressure_memory_waiting_seconds_total{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          container!="",
+          container!="POD"
+        }[$__rate_interval]
+      )
+    ) by(cluster,namespace,pod)
+      >
+    0
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    memoryPressureStalled: `sum(
+  sum(
+    sum(
+      rate(
+        container_pressure_memory_stalled_seconds_total{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          container!="",
+          container!="POD"
+        }[$__rate_interval]
+      )
+    ) by(cluster,namespace,pod)
+      >
+    0
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    ioPressureWaiting: `sum(
+  sum(
+    sum(
+      rate(
+        container_pressure_io_waiting_seconds_total{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          container!="",
+          container!="POD"
+        }[100m]
+      )
+    ) by(cluster,namespace,pod)
+      >
+    0
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    ioPressureStalled: `sum(
+  sum(
+    sum(
+      rate(
+        container_pressure_io_stalled_seconds_total{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          container!="",
+          container!="POD"
+        }[$__rate_interval]
+      )
+    ) by(cluster,namespace,pod)
+      >
+    0
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(cluster,namespace,workload,workload_type)`,
+    infoJoinKey: `label_join(
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      workload=~"$workload"
+    }
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    cpuUsageJoinKey: `label_join(
+  sum(
+    max(
+      node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    cpuRequestsJoinKey: `label_join(
+  sum(
+    max(
+      cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    cpuRequestsPercentJoinKey: `label_join(
+  sum(
+    max(
+      node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)
+  /
+label_join(
+  sum(
+    max(
+      cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    cpuLimitsJoinKey: `label_join(
+  sum(
+    max(
+      cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    cpuLimitsPercentJoinKey: `label_join(
+  sum(
+    max(
+      node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)
+  /
+label_join(
+  sum(
+    max(
+      cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    memoryUsageJoinKey: `label_join(
+  sum(
+    max(
+      node_namespace_pod_container:container_memory_working_set_bytes{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    memoryRequestsJoinKey: `label_join(
+  sum(
+    max(
+      cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    memoryRequestsPercentJoinKey: `label_join(
+  sum(
+    max(
+      node_namespace_pod_container:container_memory_working_set_bytes{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)
+  /
+label_join(
+  sum(
+    max(
+      cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    memoryLimitsJoinKey: `label_join(
+  sum(
+    max(
+      cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
+    memoryLimitsPercentJoinKey: `label_join(
+  sum(
+    max(
+      node_namespace_pod_container:container_memory_working_set_bytes{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)
+  /
+label_join(
+  sum(
+    max(
+      cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{
+        container!="POD",
+        container!="",
+        cluster=~"$cluster",
+        namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,pod,container)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace",workload=~"$workload"
+      }
+    ) by(cluster,namespace,pod,workload,workload_type)
+  ) by(cluster,namespace,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "workload",
+  "workload_type"
+)`,
   },
   pods: {
     count: `count(kube_pod_info{cluster=~"$cluster", namespace=~"$namespace", pod!=""})`,
@@ -2520,6 +3215,280 @@ sum(
     }
   ) by(cluster,node,namespace,pod,container,image)
 ) by(pod)`,
+    cpuPressureWaiting: `sum(
+  rate(
+    container_pressure_cpu_waiting_seconds_total{
+      cluster=~"$cluster",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(pod,namespace,node)
+  >
+0`,
+    cpuPressureStalled: `sum(
+  rate(
+    container_pressure_cpu_stalled_seconds_total{
+      cluster=~"$cluster",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(pod,namespace,node)
+  >
+0`,
+    memoryPressureWaiting: `sum(
+  rate(
+    container_pressure_memory_waiting_seconds_total{
+      cluster=~"$cluster",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(pod,namespace,node)
+  >
+0`,
+    memoryPressureStalled: `sum(
+  rate(
+    container_pressure_memory_stalled_seconds_total{
+      cluster=~"$cluster",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(pod,namespace,node)
+  >
+0`,
+    ioPressureWaiting: `sum(
+  rate(
+    container_pressure_io_waiting_seconds_total{
+      cluster=~"$cluster",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(pod,namespace,node)
+  >
+0`,
+    ioPressureStalled: `sum(
+  rate(
+    container_pressure_io_stalled_seconds_total{
+      cluster=~"$cluster",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(pod,namespace,node)
+  >
+0`,
+    infoJoinKey: `label_join(
+  max(
+    kube_pod_info{
+      cluster=~"$cluster",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  group(
+    namespace_workload_pod:kube_pod_owner:relabel{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,workload,workload_type),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    cpuUsageJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    cpuRequestsJoinKey: `label_join(
+  sum(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    cpuRequestsPercentJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+      cluster=~"$cluster",node=~"$node",pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node)
+    /
+  sum(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",node=~"$node",pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    cpuLimitsJoinKey: `label_join(
+  sum(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    cpuLimitsPercentJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+      cluster=~"$cluster",node=~"$node",pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node)
+    /
+  sum(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{
+      cluster=~"$cluster",node=~"$node",pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    memoryUsageJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_memory_working_set_bytes{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    memoryRequestsJoinKey: `label_join(
+  sum(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    memoryRequestsPercentJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_memory_working_set_bytes{
+      cluster=~"$cluster",node=~"$node",pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node)
+    /
+  sum(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",node=~"$node",pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    memoryLimitsJoinKey: `label_join(
+  sum(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{
+      cluster=~"$cluster",
+      node=~"$node",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
+    memoryLimitsPercentJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_memory_working_set_bytes{
+      cluster=~"$cluster",node=~"$node",pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node)
+    /
+  sum(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{
+      cluster=~"$cluster",node=~"$node",pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,node),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "node"
+)`,
   },
   containers: {
     info: `last_over_time(
@@ -2681,6 +3650,375 @@ sum(
     resource="memory"
   }
 ) by(container)`,
+    cpuDistribution: `sum(
+  max(
+    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,container)
+) by(cluster,namespace,pod,container)`,
+    cpuEfficiency: `sum(
+  sum(
+    max(
+      node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+        cluster=~"$cluster",
+        namespace=~"$namespace",
+        pod=~"$pod"
+      }
+    ) by(cluster,namespace,pod,container)
+  ) by(cluster,namespace,pod,container)
+) by(cluster,namespace,pod,container)
+  /
+sum(
+  max(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,container)
+) by(cluster,namespace,pod,container)`,
+    memoryDistribution: `sum(
+  max(
+    node_namespace_pod_container:container_memory_working_set_bytes{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,container)
+) by(cluster,namespace,pod,container)`,
+    memoryEfficiency: `sum(
+  sum(
+    max(
+      node_namespace_pod_container:container_memory_working_set_bytes{
+        cluster=~"$cluster",
+        namespace=~"$namespace",
+        pod=~"$pod"
+      }
+    ) by(cluster,namespace,pod,container)
+  ) by(cluster,namespace,pod,container)
+) by(cluster,namespace,pod,container)
+  /
+sum(
+  max(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,container)
+) by(cluster,namespace,pod,container)`,
+    cpuPressureWaiting: `sum(
+  rate(
+    container_pressure_cpu_waiting_seconds_total{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(cluster,namespace,pod,container)
+  >
+0`,
+    cpuPressureStalled: `sum(
+  rate(
+    container_pressure_cpu_stalled_seconds_total{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(cluster,namespace,pod,container)
+  >
+0`,
+    memoryPressureWaiting: `sum(
+  rate(
+    container_pressure_memory_waiting_seconds_total{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(cluster,namespace,pod,container)
+  >
+0`,
+    memoryPressureStalled: `sum(
+  rate(
+    container_pressure_memory_stalled_seconds_total{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(cluster,namespace,pod,container)
+  >
+0`,
+    ioPressureWaiting: `sum(
+  rate(
+    container_pressure_io_waiting_seconds_total{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(cluster,namespace,pod,container)
+  >
+0`,
+    ioPressureStalled: `sum(
+  rate(
+    container_pressure_io_stalled_seconds_total{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }[$__rate_interval]
+  )
+) by(cluster,namespace,pod,container)
+  >
+0`,
+    infoJoinKey: `label_join(
+  max(
+    kube_pod_container_info{
+      cluster=~"$cluster",namespace=~"$namespace",pod=~"$pod"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    cpuUsageJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    cpuRequestsJoinKey: `label_join(
+  sum(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    cpuRequestsPercentJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container)
+    /
+  sum(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    cpuLimitsJoinKey: `label_join(
+  sum(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    cpuLimitsPercentJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container)
+    /
+  sum(
+    cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    memoryUsageJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_memory_working_set_bytes{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    memoryRequestsJoinKey: `label_join(
+  sum(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    memoryRequestsPercentJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_memory_working_set_bytes{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container)
+    /
+  sum(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    memoryLimitsJoinKey: `label_join(
+  sum(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
+    memoryLimitsPercentJoinKey: `label_join(
+  sum(
+    node_namespace_pod_container:container_memory_working_set_bytes{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container)
+    /
+  sum(
+    cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{
+      cluster=~"$cluster",
+      namespace=~"$namespace",
+      pod=~"$pod",
+      container!="",
+      container!="POD"
+    }
+  ) by(cluster,namespace,pod,container),
+  "join_key",
+  ".",
+  "cluster",
+  "namespace",
+  "pod",
+  "container"
+)`,
   },
   persistentVolumeClaims: {
     count: `count(

--- a/src/components/metrics/shared/TableMemoryOrCPUUsage.tsx
+++ b/src/components/metrics/shared/TableMemoryOrCPUUsage.tsx
@@ -1,0 +1,280 @@
+import React from 'react';
+import { DataTransformerID } from '@grafana/data';
+import {
+  useDataTransformer,
+  useQueryRunner,
+  VizPanel,
+} from '@grafana/scenes-react';
+import { SceneDataQuery, VizConfigBuilders } from '@grafana/scenes';
+
+import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+import { ROUTES } from '../../../constants';
+import { prefixRoute } from '../../../utils/utils.routing';
+
+interface Props {
+  title: string;
+  unit: string;
+  infoExpr?: string;
+  infoContainerExpr?: string;
+  usageExpr?: string;
+  requestsExpr?: string;
+  requestsPercentExpr?: string;
+  limitsExpr?: string;
+  limitsPercentExpr?: string;
+}
+
+export function TableMemoryOrCPUUsage({
+  title,
+  unit,
+  infoExpr,
+  infoContainerExpr,
+  usageExpr,
+  requestsExpr,
+  requestsPercentExpr,
+  limitsExpr,
+  limitsPercentExpr,
+}: Props) {
+  const queries: SceneDataQuery[] = [];
+
+  if (infoExpr) {
+    queries.push({
+      refId: 'info',
+      format: 'table',
+      instant: true,
+      expr: infoExpr,
+    });
+  }
+  if (infoContainerExpr) {
+    queries.push({
+      refId: 'info_container',
+      format: 'table',
+      instant: true,
+      expr: infoContainerExpr,
+    });
+  }
+  if (usageExpr) {
+    queries.push({
+      refId: 'usage',
+      format: 'table',
+      instant: true,
+      expr: usageExpr,
+    });
+  }
+  if (requestsExpr) {
+    queries.push({
+      refId: 'requests',
+      format: 'table',
+      instant: true,
+      expr: requestsExpr,
+    });
+  }
+  if (requestsPercentExpr) {
+    queries.push({
+      refId: 'requests_percent',
+      format: 'table',
+      instant: true,
+      expr: requestsPercentExpr,
+    });
+  }
+  if (limitsExpr) {
+    queries.push({
+      refId: 'limits',
+      format: 'table',
+      instant: true,
+      expr: limitsExpr,
+    });
+  }
+  if (limitsPercentExpr) {
+    queries.push({
+      refId: 'limits_percent',
+      format: 'table',
+      instant: true,
+      expr: limitsPercentExpr,
+    });
+  }
+
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: queries,
+  });
+
+  const dataTransformer = useDataTransformer({
+    data: dataProvider,
+    transformations: [
+      {
+        id: DataTransformerID.joinByField,
+        options: {
+          byField: 'join_key',
+          mode: 'outer',
+        },
+      },
+      {
+        id: DataTransformerID.organize,
+        options: {
+          includeByName: {
+            ['node 1']: infoContainerExpr ? false : true,
+            ['namespace 1']: infoContainerExpr ? false : true,
+            ['workload 1']: infoContainerExpr ? false : true,
+            ['workload_type 1']: infoContainerExpr ? false : true,
+            ['pod 1']: infoContainerExpr ? false : true,
+            ['container 1']: infoContainerExpr ? true : false,
+            ['Value #usage']: true,
+            ['Value #requests']: true,
+            ['Value #requests_percent']: true,
+            ['Value #limits']: true,
+            ['Value #limits_percent']: true,
+          },
+          indexByName: {
+            ['namespace 1']: 0,
+            ['pod 1']: 1,
+            ['container 1']: 2,
+            ['node 1']: 3,
+            ['workload 1']: 4,
+            ['workload_type 1']: 5,
+            ['Value #usage']: 6,
+            ['Value #requests']: 7,
+            ['Value #requests_percent']: 8,
+            ['Value #limits']: 9,
+            ['Value #limits_percent']: 10,
+          },
+          renameByName: {
+            ['node 1']: 'NODE',
+            ['namespace 1']: 'NAMESPACE',
+            ['workload 1']: 'WORKLOAD',
+            ['workload_type 1']: 'WORKLOAD TYPE',
+            ['pod 1']: 'POD',
+            ['container 1']: 'CONTAINER',
+            ['Value #usage']: 'USAGE',
+            ['Value #requests']: 'REQUESTS',
+            ['Value #requests_percent']: 'REQUESTS %',
+            ['Value #limits']: 'LIMITS',
+            ['Value #limits_percent']: 'LIMITS %',
+          },
+        },
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.table()
+    .setOption('sortBy', [
+      {
+        desc: false,
+        displayName: 'NAMESPACE',
+      },
+      {
+        desc: false,
+        displayName: 'POD',
+      },
+      {
+        desc: false,
+        displayName: 'NODE',
+      },
+      {
+        desc: false,
+        displayName: 'WORKLOAD',
+      },
+      {
+        desc: false,
+        displayName: 'WORKLOAD TYPE',
+      },
+    ])
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('node')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsNodes)}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('namespace')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsNamespaces)}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('workload')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsWorkloads)}/\${__data.fields["namespace"].text}/\${__data.fields["workload_type"].text}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('workload_type')
+        .overrideCustomFieldConfig('width', 150)
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('pod')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsPods)}/\${__data.fields["namespace"].text}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('container')
+        .overrideCustomFieldConfig('width', 200)
+        .build();
+    })
+    .setOverrides((b) =>
+      b.matchFieldsWithName('Value #usage').overrideUnit(unit),
+    )
+    .setOverrides((b) =>
+      b.matchFieldsWithName('Value #requests').overrideUnit(unit),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsWithName('Value #requests_percent')
+        .overrideUnit('percentunit')
+        .overrideCustomFieldConfig('width', 150),
+    )
+    .setOverrides((b) =>
+      b.matchFieldsWithName('Value #limits').overrideUnit(unit),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsWithName('Value #limits_percent')
+        .overrideUnit('percentunit')
+        .overrideCustomFieldConfig('width', 150),
+    )
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title={title}
+      menu={menu}
+      viz={viz}
+      dataProvider={dataTransformer}
+    />
+  );
+}

--- a/src/components/metrics/shared/TableResourceUsage.tsx
+++ b/src/components/metrics/shared/TableResourceUsage.tsx
@@ -211,7 +211,7 @@ export function TableResourceUsage({
             ['workload']: infoContainerExpr ? false : true,
             ['workload_type']: infoContainerExpr ? false : true,
             ['pod']: infoContainerExpr ? false : true,
-            ['container']: true,
+            ['container']: infoContainerExpr ? true : false,
             ['phase']: true,
             ['image_spec']: true,
             ['Value #info_namespace']: true,

--- a/src/components/metrics/shared/TimeSeriesMemoryOrCPU.tsx
+++ b/src/components/metrics/shared/TimeSeriesMemoryOrCPU.tsx
@@ -111,7 +111,7 @@ export function TimeSeriesMemoryOrCPU({
           fixedColor: 'red',
         })
         .overrideCustomFieldConfig('lineStyle', {
-          dash: [1, 1],
+          dash: [10, 10],
           fill: 'dash',
         }),
     )
@@ -123,7 +123,7 @@ export function TimeSeriesMemoryOrCPU({
           fixedColor: 'orange',
         })
         .overrideCustomFieldConfig('lineStyle', {
-          dash: [1, 1],
+          dash: [10, 10],
           fill: 'dash',
         }),
     )

--- a/src/components/metrics/shared/TimeSeriesMemoryOrCPUDistribution.tsx
+++ b/src/components/metrics/shared/TimeSeriesMemoryOrCPUDistribution.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useQueryRunner, VizPanel } from '@grafana/scenes-react';
+import {
+  FieldColorModeId,
+  LegendDisplayMode,
+  StackingMode,
+} from '@grafana/schema';
+import { SceneDataQuery, VizConfigBuilders } from '@grafana/scenes';
+
+import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+
+interface Props {
+  title: string;
+  unit: string;
+  expr: string;
+  legend: string;
+}
+
+export function TimeSeriesMemoryOrCPUDistribution({
+  title,
+  unit,
+  expr,
+  legend,
+}: Props) {
+  const queries: SceneDataQuery[] = [
+    {
+      refId: 'distribution',
+      format: 'time_series',
+      expr: expr,
+      legendFormat: legend,
+    },
+  ];
+
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: queries,
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setUnit(unit)
+    .setOption('legend', {
+      asTable: true,
+      displayMode: LegendDisplayMode.Table,
+      placement: 'bottom',
+    })
+    .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
+    .setCustomFieldConfig('fillOpacity', 100)
+    .setColor({
+      mode: FieldColorModeId.Shades,
+      fixedColor: 'blue',
+    })
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel title={title} menu={menu} viz={viz} dataProvider={dataProvider} />
+  );
+}

--- a/src/components/metrics/shared/TimeSeriesMemoryOrCPUEfficiency.tsx
+++ b/src/components/metrics/shared/TimeSeriesMemoryOrCPUEfficiency.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useQueryRunner, VizPanel } from '@grafana/scenes-react';
+import {
+  FieldColorModeId,
+  GraphThresholdsStyleMode,
+  LegendDisplayMode,
+  ThresholdsMode,
+} from '@grafana/schema';
+import { SceneDataQuery, VizConfigBuilders } from '@grafana/scenes';
+
+import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+
+interface Props {
+  title: string;
+  unit: string;
+  expr: string;
+  legend: string;
+}
+
+export function TimeSeriesMemoryOrCPUEfficiency({
+  title,
+  unit,
+  expr,
+  legend,
+}: Props) {
+  const queries: SceneDataQuery[] = [
+    {
+      refId: 'distribution',
+      format: 'time_series',
+      expr: expr,
+      legendFormat: legend,
+    },
+  ];
+
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: queries,
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setUnit(unit)
+    .setOption('legend', {
+      asTable: true,
+      displayMode: LegendDisplayMode.Table,
+      placement: 'bottom',
+    })
+    .setColor({
+      mode: FieldColorModeId.Shades,
+      fixedColor: 'blue',
+    })
+    .setThresholds({
+      mode: ThresholdsMode.Absolute,
+      steps: [
+        {
+          color: 'transparent',
+          value: 0,
+        },
+        {
+          color: 'green',
+          value: 0.6,
+        },
+        {
+          color: 'red',
+          value: 0.9,
+        },
+      ],
+    })
+    .setCustomFieldConfig('thresholdsStyle', {
+      mode: GraphThresholdsStyleMode.Dashed,
+    })
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel title={title} menu={menu} viz={viz} dataProvider={dataProvider} />
+  );
+}

--- a/src/components/metrics/workloads/WorkloadPage.tsx
+++ b/src/components/metrics/workloads/WorkloadPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
-import { Alert, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
+import { Alert, Badge, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import {
   SceneContextProvider,
   DataSourceVariable,
@@ -18,6 +18,8 @@ import { getStyles } from '../../../utils/utils.styles';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { WorkloadPageOverview } from './WorkloadPageOverview';
 import { queries, variableQuery } from '../queries';
+import { WorkloadPageMemory } from './WorkloadPageMemory';
+import { WorkloadPageCPU } from './WorkloadPageCPU';
 
 export function WorkloadPage() {
   const styles = useStyles2(getStyles);
@@ -127,13 +129,18 @@ export function WorkloadPage() {
                     >
                       <PluginPage
                         renderTitle={() => (
-                          <Stack gap={0}>
+                          <Stack gap={0} alignItems="center" direction="row">
                             <img
                               className={styles.pluginPage.title.image}
                               alt={workload}
                               src={resourcesImg}
                             />
                             <h1>{workload}</h1>
+                            <Badge
+                              className={styles.pluginPage.title.badge}
+                              color="blue"
+                              text={workloadType.toLowerCase()}
+                            />
                           </Stack>
                         )}
                         subTitle={pluginJson.info.description}
@@ -191,6 +198,8 @@ export function WorkloadPage() {
                             workloadType={workloadType.toLowerCase()}
                           />
                         )}
+                        {activeTab === 'cpu' && <WorkloadPageCPU />}
+                        {activeTab === 'memory' && <WorkloadPageMemory />}
                       </PluginPage>
                     </QueryVariable>
                   </CustomVariable>

--- a/src/components/metrics/workloads/WorkloadPageCPU.tsx
+++ b/src/components/metrics/workloads/WorkloadPageCPU.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+import { TimeSeriesMemoryOrCPUEfficiency } from '../shared/TimeSeriesMemoryOrCPUEfficiency';
+import { TableMemoryOrCPUUsage } from '../shared/TableMemoryOrCPUUsage';
+
+export function WorkloadPageCPU() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="node" />
+        <VariableControl name="namespace" />
+        <VariableControl name="pod" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPU
+          title="Overview: Usage"
+          unit="cores"
+          allocationExpr={queries.workloads.cpuAllocation}
+          limitsExpr={queries.workloads.cpuLimits}
+          requestsExpr={queries.workloads.cpuRequests}
+          usageExpr={queries.workloads.cpuUsage}
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Distribution: Pod Usage / Node Capacity"
+          unit="cores"
+          expr={queries.pods.cpuUsage}
+          legend="{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUEfficiency
+          title="Efficiency: Pod Usage"
+          unit="percentunit"
+          expr={queries.nodes.cpuEfficiency}
+          legend="{{ pod }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Waiting"
+          unit="s"
+          expr={queries.pods.cpuPressureWaiting}
+          legend="{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Stalled"
+          unit="s"
+          expr={queries.pods.cpuPressureStalled}
+          legend="{{ pod }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TableMemoryOrCPUUsage
+          title="Pods"
+          unit="cores"
+          infoExpr={queries.pods.infoJoinKey}
+          usageExpr={queries.pods.cpuUsageJoinKey}
+          requestsExpr={queries.pods.cpuRequestsJoinKey}
+          requestsPercentExpr={queries.pods.cpuRequestsPercentJoinKey}
+          limitsExpr={queries.pods.cpuLimitsJoinKey}
+          limitsPercentExpr={queries.pods.cpuLimitsPercentJoinKey}
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/workloads/WorkloadPageMemory.tsx
+++ b/src/components/metrics/workloads/WorkloadPageMemory.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+import { TimeSeriesMemoryOrCPUEfficiency } from '../shared/TimeSeriesMemoryOrCPUEfficiency';
+import { TableMemoryOrCPUUsage } from '../shared/TableMemoryOrCPUUsage';
+
+export function WorkloadPageMemory() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="node" />
+        <VariableControl name="namespace" />
+        <VariableControl name="pod" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPU
+          title="Workload Memory"
+          unit="bytes"
+          allocationExpr={queries.workloads.memoryAllocation}
+          limitsExpr={queries.workloads.memoryLimits}
+          requestsExpr={queries.workloads.memoryRequests}
+          usageExpr={queries.workloads.memoryUsage}
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Distribution: Pod Usage"
+          unit="bytes"
+          expr={queries.pods.memoryUsage}
+          legend="{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUEfficiency
+          title="Efficiency: Pod Usage / Requests"
+          unit="percentunit"
+          expr={queries.nodes.memoryEfficiency}
+          legend="{{ pod }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Waiting"
+          unit="s"
+          expr={queries.pods.memoryPressureWaiting}
+          legend="{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Stalled"
+          unit="s"
+          expr={queries.pods.memoryPressureStalled}
+          legend="{{ pod }}"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TableMemoryOrCPUUsage
+          title="Pods"
+          unit="bytes"
+          infoExpr={queries.pods.infoJoinKey}
+          usageExpr={queries.pods.memoryUsageJoinKey}
+          requestsExpr={queries.pods.memoryRequestsJoinKey}
+          requestsPercentExpr={queries.pods.memoryRequestsPercentJoinKey}
+          limitsExpr={queries.pods.memoryLimitsJoinKey}
+          limitsPercentExpr={queries.pods.memoryLimitsPercentJoinKey}
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/workloads/WorkloadsPage.tsx
+++ b/src/components/metrics/workloads/WorkloadsPage.tsx
@@ -100,7 +100,7 @@ export function WorkloadsPage() {
               >
                 <PluginPage
                   renderTitle={() => (
-                    <Stack gap={0}>
+                    <Stack gap={0} alignItems="center" direction="row">
                       <img
                         className={styles.pluginPage.title.image}
                         alt="Workloads"

--- a/src/components/resources/ResourcesPage.tsx
+++ b/src/components/resources/ResourcesPage.tsx
@@ -45,7 +45,7 @@ export const ResourcesPage = () => {
   return (
     <PluginPage
       renderTitle={() => (
-        <Stack gap={0}>
+        <Stack gap={0} alignItems="center" direction="row">
           <img
             className={styles.title.image}
             alt="Resources"

--- a/src/utils/utils.styles.ts
+++ b/src/utils/utils.styles.ts
@@ -10,6 +10,9 @@ export function getStyles(theme: GrafanaTheme2) {
           height: '32px',
           marginRight: '16px',
         }),
+        badge: css({
+          marginLeft: theme.spacing(2),
+        }),
       },
       section: css({
         marginTop: theme.spacing(4),


### PR DESCRIPTION
This commit adds the details metrics for CPU and memory usage of nodes,
namespaces, workloads and pods. For each resource the following
information are added:

- Distribution of CPU and memory usage across the resource's children
- Efficiency of CPU and memory usage across the resource's children
- Pressure of CPU and memory usage across the resource's children
- A table showing the CPU and memory usage of the resource's children
