### PR TITLE
Add Network Details Metrics

### DIFF
--- a/src/components/metrics/namespaces/NamespacePage.tsx
+++ b/src/components/metrics/namespaces/NamespacePage.tsx
@@ -20,6 +20,7 @@ import { queries, variableQuery } from '../queries';
 import { NamespacePageOverview } from './NamespacePageOverview';
 import { NamespacePageCPU } from './NamespacePageCPU';
 import { NamespacePageMemory } from './NamespacePageMemory';
+import { NamespacePageNetwork } from './NamespacePageNetwork';
 
 export function NamespacePage() {
   const styles = useStyles2(getStyles);
@@ -165,6 +166,7 @@ export function NamespacePage() {
                   {activeTab === 'overview' && <NamespacePageOverview />}
                   {activeTab === 'cpu' && <NamespacePageCPU />}
                   {activeTab === 'memory' && <NamespacePageMemory />}
+                  {activeTab === 'network' && <NamespacePageNetwork />}
                 </PluginPage>
               </QueryVariable>
             </CustomVariable>

--- a/src/components/metrics/namespaces/NamespacePageNetwork.tsx
+++ b/src/components/metrics/namespaces/NamespacePageNetwork.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesNetwork } from '../shared/TimeSeriesNetwork';
+
+export function NamespacePageNetwork() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="namespace" />
+        <VariableControl name="workload" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesNetwork
+          title="Network Bandwidth"
+          unit="binBps"
+          color="blue"
+          rxExpr={queries.namespaces.networkBandwidthRx}
+          txExpr={queries.namespaces.networkBandwidthTx}
+          rxLegend="Rx"
+          txLegend="Tx"
+        />
+        <TimeSeriesNetwork
+          title="Network Saturation"
+          unit="pps"
+          color="red"
+          rxExpr={queries.namespaces.networkSaturationRx}
+          txExpr={queries.namespaces.networkSaturationTx}
+          rxLegend="Rx dropped packets"
+          txLegend="Tx dropped packets"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesNetwork
+          title="Network Bandwidth by Workload"
+          unit="binBps"
+          color="blue"
+          rxExpr={queries.namespaces.networkBandwidthByWorkloadRx}
+          txExpr={queries.namespaces.networkBandwidthByWorkloadTx}
+          rxLegend="Rx ({{workload_type}}/{{workload}})"
+          txLegend="Tx ({{workload_type}}/{{workload}})"
+        />
+        <TimeSeriesNetwork
+          title="Network Saturation by Workload"
+          unit="pps"
+          color="red"
+          rxExpr={queries.namespaces.networkSaturationByWorkloadRx}
+          txExpr={queries.namespaces.networkSaturationByWorkloadTx}
+          rxLegend="Rx dropped packets ({{workload_type}}/{{workload}})"
+          txLegend="Tx dropped packets ({{workload_type}}/{{workload}})"
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/nodes/NodePage.tsx
+++ b/src/components/metrics/nodes/NodePage.tsx
@@ -20,6 +20,7 @@ import { queries, variableQuery } from '../queries';
 import { NodePageOverview } from './NodePageOverview';
 import { NodePageCPU } from './NodePageCPU';
 import { NodePageMemory } from './NodePageMemory';
+import { NodePageNetwork } from './NodePageNetwork';
 
 export function NodePage() {
   const styles = useStyles2(getStyles);
@@ -168,6 +169,7 @@ export function NodePage() {
                     {activeTab === 'overview' && <NodePageOverview />}
                     {activeTab === 'cpu' && <NodePageCPU />}
                     {activeTab === 'memory' && <NodePageMemory />}
+                    {activeTab === 'network' && <NodePageNetwork />}
                   </PluginPage>
                 </QueryVariable>
               </CustomVariable>

--- a/src/components/metrics/nodes/NodePageNetwork.tsx
+++ b/src/components/metrics/nodes/NodePageNetwork.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesNetwork } from '../shared/TimeSeriesNetwork';
+
+export function NodePageNetwork() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="node" />
+        <VariableControl name="namespace" />
+        <VariableControl name="pod" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesNetwork
+          title="Network Bandwidth"
+          unit="binBps"
+          color="blue"
+          rxExpr={queries.nodes.networkBandwidthRx}
+          txExpr={queries.nodes.networkBandwidthTx}
+          rxLegend="Rx"
+          txLegend="Tx"
+        />
+        <TimeSeriesNetwork
+          title="Network Saturation"
+          unit="pps"
+          color="red"
+          rxExpr={queries.nodes.networkSaturationRx}
+          txExpr={queries.nodes.networkSaturationTx}
+          rxLegend="Rx dropped packets"
+          txLegend="Tx dropped packets"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesNetwork
+          title="Network Bandwidth by Pod"
+          unit="binBps"
+          color="blue"
+          rxExpr={queries.nodes.networkBandwidthByPodRx}
+          txExpr={queries.nodes.networkBandwidthByPodTx}
+          rxLegend="Rx ({{namespace}}/{{pod}})"
+          txLegend="Tx ({{namespace}}/{{pod}})"
+        />
+        <TimeSeriesNetwork
+          title="Network Saturation by Pod"
+          unit="pps"
+          color="red"
+          rxExpr={queries.nodes.networkSaturationByPodRx}
+          txExpr={queries.nodes.networkSaturationByPodTx}
+          rxLegend="Rx dropped packets ({{namespace}}/{{pod}})"
+          txLegend="Tx dropped packets ({{namespace}}/{{pod}})"
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/pods/PodPage.tsx
+++ b/src/components/metrics/pods/PodPage.tsx
@@ -19,6 +19,7 @@ import datasourcePluginJson from '../../../datasource/plugin.json';
 import { PodPageOverview } from './PodPageOverview';
 import { PodPageCPU } from './PodPageCPU';
 import { PodPageMemory } from './PodPageMemory';
+import { PodPageNetwork } from './PodPageNetwork';
 
 export function PodPage() {
   const styles = useStyles2(getStyles);
@@ -154,6 +155,7 @@ export function PodPage() {
                   {activeTab === 'overview' && <PodPageOverview />}
                   {activeTab === 'cpu' && <PodPageCPU />}
                   {activeTab === 'memory' && <PodPageMemory />}
+                  {activeTab === 'network' && <PodPageNetwork />}
                 </PluginPage>
               </CustomVariable>
             </CustomVariable>

--- a/src/components/metrics/pods/PodPageNetwork.tsx
+++ b/src/components/metrics/pods/PodPageNetwork.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesNetwork } from '../shared/TimeSeriesNetwork';
+
+export function PodPageNetwork() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="namespace" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesNetwork
+          title="Network Bandwidth"
+          unit="binBps"
+          color="blue"
+          rxExpr={queries.pods.networkBandwidthRx}
+          txExpr={queries.pods.networkBandwidthTx}
+          rxLegend="Rx"
+          txLegend="Tx"
+        />
+        <TimeSeriesNetwork
+          title="Network Saturation"
+          unit="pps"
+          color="red"
+          rxExpr={queries.pods.networkSaturationRx}
+          txExpr={queries.pods.networkSaturationTx}
+          rxLegend="Rx dropped packets"
+          txLegend="Tx dropped packets"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesNetwork
+          title="Network Bandwidth by Interface"
+          unit="binBps"
+          color="blue"
+          rxExpr={queries.pods.networkBandwidthByInterfaceRx}
+          txExpr={queries.pods.networkBandwidthByInterfaceTx}
+          rxLegend="Rx ({{interface}})"
+          txLegend="Tx ({{interface}})"
+        />
+        <TimeSeriesNetwork
+          title="Network Saturation by Interface"
+          unit="pps"
+          color="red"
+          rxExpr={queries.pods.networkSaturationByInterfaceRx}
+          txExpr={queries.pods.networkSaturationByInterfaceTx}
+          rxLegend="Rx dropped packets ({{interface}})"
+          txLegend="Tx dropped packets ({{interface}})"
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/queries.ts
+++ b/src/components/metrics/queries.ts
@@ -722,6 +722,150 @@ sum(
     }
   ) by(cluster,namespace,pod,container,node)
 ) by(cluster,namespace,pod,node)`,
+    networkBandwidthRx: `sum(
+  max(
+    rate(
+      windows_net_bytes_received_total{
+        cluster=~"$cluster",
+        instance=~"$node(:[0-9]{2,5})?"
+      }[$__rate_interval]
+    )
+      or
+    rate(
+      node_network_receive_bytes_total{
+        cluster=~"$cluster",
+        instance=~"$node(:[0-9]{2,5})?"
+      }[$__rate_interval]
+    )
+  ) by(cluster,instance,device)
+)`,
+    networkBandwidthTx: `-sum(
+  max(
+    rate(
+      windows_net_bytes_sent_total{
+        cluster=~"$cluster",
+        instance=~"$node(:[0-9]{2,5})?"
+      }[$__rate_interval]
+    )
+      or
+    rate(
+      node_network_transmit_bytes_total{
+        cluster=~"$cluster",
+        instance=~"$node(:[0-9]{2,5})?"
+      }[$__rate_interval]
+    )
+  ) by(cluster,instance,device)
+)`,
+    networkSaturationRx: `sum(
+  max(
+    rate(
+      node_network_receive_drop_total{
+        cluster=~"$cluster",
+        instance=~"$node(:[0-9]{2,5})?"
+      }[$__rate_interval]
+    )
+      or
+    sum(
+      rate(
+        windows_container_network_receive_packets_dropped_total{
+          cluster=~"$cluster",
+          instance=~"$node"
+        }[$__rate_interval]
+      )
+    ) by(cluster,instance,interface)
+  ) by(cluster,instance,device,interface)
+)`,
+    networkSaturationTx: `-sum(
+  max(
+    rate(
+      node_network_transmit_drop_total{
+        cluster=~"$cluster",
+        instance=~"$node(:[0-9]{2,5})?"
+      }[$__rate_interval]
+    )
+      or
+    sum(
+      rate(
+        windows_container_network_transmit_packets_dropped_total{
+          cluster=~"$cluster",
+          instance=~"$node"
+        }[$__rate_interval]
+      )
+    ) by(cluster,instance,interface)
+  ) by(cluster,instance,device,interface)
+)`,
+    networkBandwidthByPodRx: `sum(
+  max(
+    rate(
+      container_network_receive_bytes_total{cluster=~"$cluster",pod=~"$pod"}[$__rate_interval]
+    )
+      or
+    (
+      rate(
+        windows_container_network_receive_bytes_total{
+          cluster=~"$cluster",instance=~"$node"
+        }[$__rate_interval]
+      )
+        * on(container_id) group_left(pod,namespace)
+      kube_pod_container_info{cluster=~"$cluster",node=~"$node",pod=~"$pod"}
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(cluster,namespace,pod)`,
+    networkBandwidthByPodTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_bytes_total{cluster=~"$cluster",pod=~"$pod"}[$__rate_interval]
+    )
+      or
+    (
+      rate(
+        windows_container_network_transmit_bytes_total{
+          cluster=~"$cluster",instance=~"$node"
+        }[$__rate_interval]
+      )
+        * on(container_id) group_left(pod,namespace)
+      kube_pod_container_info{cluster=~"$cluster",node=~"$node",pod=~"$pod"}
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(cluster,namespace,pod)`,
+    networkSaturationByPodRx: `sum(
+  max(
+    rate(
+      container_network_receive_packets_dropped_total{
+        cluster=~"$cluster",pod=~"$pod"
+      }[$__rate_interval]
+    )
+      or
+    (
+      rate(
+        windows_container_network_receive_packets_dropped_total{
+          cluster=~"$cluster",instance=~"$node"
+        }[$__rate_interval]
+      )
+        * on(container_id) group_left(pod,namespace)
+      kube_pod_container_info{cluster=~"$cluster",instance=~"$node",pod=~"$pod"}
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(cluster,namespace,pod)`,
+    networkSaturationByPodTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_packets_dropped_total{
+        cluster=~"$cluster",pod=~"$pod"
+      }[$__rate_interval]
+    )
+      or
+    (
+      rate(
+        windows_container_network_transmit_packets_dropped_total{
+          cluster=~"$cluster",instance=~"$node"
+        }[$__rate_interval]
+      )
+        * on(container_id) group_left(pod,namespace)
+      kube_pod_container_info{cluster=~"$cluster",instance=~"$node",pod=~"$pod"}
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(cluster,namespace,pod)`,
   },
   namespaces: {
     labelsByCluster: `label_values(kube_namespace_status_phase{cluster=~"$cluster"}, namespace)`,
@@ -993,6 +1137,118 @@ sum(
     }
   ) by(cluster,namespace,pod,container)
 )`,
+    networkBandwidthRx: `sum(
+  max(
+    rate(
+      container_network_receive_bytes_total{
+        cluster=~"$cluster",namespace="$namespace"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkBandwidthTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_bytes_total{
+        cluster=~"$cluster",namespace="$namespace"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkSaturationRx: `sum(
+  max(
+    rate(
+      container_network_receive_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod!=""
+      }[$__rate_interval]
+    )
+  ) by(namespace,pod,interface)
+)`,
+    networkSaturationTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod!=""
+      }[$__rate_interval]
+    )
+  ) by(namespace,pod,interface)
+)`,
+    networkBandwidthByWorkloadRx: `sum(
+  max(
+    rate(
+      container_network_receive_bytes_total{
+        cluster=~"$cluster",namespace="$namespace"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  topk(
+    1,
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,workload,workload_type,pod)
+  ) by(cluster,namespace,pod)
+) by(cluster,namespace,workload,workload_type)`,
+    networkBandwidthByWorkloadTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_bytes_total{
+        cluster=~"$cluster",namespace="$namespace"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  topk(
+    1,
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,workload,workload_type,pod)
+  ) by(cluster,namespace,pod)
+) by(cluster,namespace,workload,workload_type)`,
+    networkSaturationByWorkloadRx: `sum(
+  max(
+    rate(
+      container_network_receive_packets_dropped_total{
+        cluster=~"$cluster",namespace="$namespace"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  topk(
+    1,
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,workload,workload_type,pod)
+  ) by(cluster,namespace,pod)
+) by(cluster,namespace,workload,workload_type)`,
+    networkSaturationByWorkloadTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_packets_dropped_total{
+        cluster=~"$cluster",namespace="$namespace"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+    * on(cluster,namespace,pod) group_left(workload,workload_type)
+  topk(
+    1,
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",namespace=~"$namespace"
+      }
+    ) by(cluster,namespace,workload,workload_type,pod)
+  ) by(cluster,namespace,pod)
+) by(cluster,namespace,workload,workload_type)`,
   },
   workloads: {
     labelsByClusterNamespace: `query_result(
@@ -2879,6 +3135,86 @@ label_join(
   "workload",
   "workload_type"
 )`,
+    networkBandwidthRx: `sum(
+  max(
+    rate(
+      container_network_receive_bytes_total{
+        cluster=~"$cluster",namespace="$namespace",pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkBandwidthTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_bytes_total{
+        cluster=~"$cluster",namespace="$namespace",pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkSaturationRx: `sum(
+  max(
+    rate(
+      container_network_receive_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkSaturationTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkBandwidthByPodRx: `sum(
+  max(
+    rate(
+      container_network_receive_bytes_total{
+        cluster=~"$cluster",namespace="$namespace",pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(cluster,namespace,pod)`,
+    networkBandwidthByPodTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_bytes_total{
+        cluster=~"$cluster",namespace="$namespace",pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(cluster,namespace,pod)`,
+    networkSaturationByPodRx: `sum(
+  max(
+    rate(
+      container_network_receive_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(cluster,namespace,pod)`,
+    networkSaturationByPodTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(cluster,namespace,pod)`,
   },
   pods: {
     count: `count(kube_pod_info{cluster=~"$cluster", namespace=~"$namespace", pod!=""})`,
@@ -3489,6 +3825,86 @@ sum(
   "pod",
   "node"
 )`,
+    networkBandwidthRx: `sum(
+  max(
+    rate(
+      container_network_receive_bytes_total{
+        cluster=~"$cluster",namespace="$namespace",pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkBandwidthTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_bytes_total{
+        cluster=~"$cluster",namespace="$namespace",pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkSaturationRx: `sum(
+  max(
+    rate(
+      container_network_receive_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkSaturationTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+)`,
+    networkBandwidthByInterfaceRx: `sum(
+  max(
+    rate(
+      container_network_receive_bytes_total{
+        cluster=~"$cluster",namespace="$namespace",pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(interface)`,
+    networkBandwidthByInterfaceTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_bytes_total{
+        cluster=~"$cluster",namespace="$namespace",pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(interface)`,
+    networkSaturationByInterfaceRx: `sum(
+  max(
+    rate(
+      container_network_receive_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(interface)`,
+    networkSaturationByInterfaceTx: `-sum(
+  max(
+    rate(
+      container_network_transmit_packets_dropped_total{
+        cluster=~"$cluster",
+        namespace="$namespace",
+        pod=~"$pod"
+      }[$__rate_interval]
+    )
+  ) by(cluster,namespace,pod,interface)
+) by(interface)`,
   },
   containers: {
     info: `last_over_time(

--- a/src/components/metrics/shared/TimeSeriesNetwork.tsx
+++ b/src/components/metrics/shared/TimeSeriesNetwork.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { useQueryRunner, VizPanel } from '@grafana/scenes-react';
+import { LegendDisplayMode } from '@grafana/schema';
+import { SceneDataQuery, VizConfigBuilders } from '@grafana/scenes';
+
+import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+
+interface Props {
+  title: string;
+  unit: 'binBps' | 'pps';
+  color: 'blue' | 'red';
+  rxExpr: string;
+  txExpr: string;
+  rxLegend: string;
+  txLegend: string;
+}
+
+export function TimeSeriesNetwork({
+  title,
+  unit,
+  color,
+  rxExpr,
+  txExpr,
+  rxLegend,
+  txLegend,
+}: Props) {
+  const queries: SceneDataQuery[] = [
+    {
+      refId: 'rx',
+      format: 'time_series',
+      expr: rxExpr,
+      legendFormat: rxLegend,
+    },
+    {
+      refId: 'tx',
+      format: 'time_series',
+      expr: txExpr,
+      legendFormat: txLegend,
+    },
+  ];
+
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: queries,
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setUnit(unit)
+    .setOption('legend', {
+      asTable: true,
+      displayMode: LegendDisplayMode.Table,
+      placement: 'bottom',
+    })
+    .setCustomFieldConfig('axisSoftMin', -100)
+    .setCustomFieldConfig('axisSoftMax', 100)
+    .setOverrides((b) =>
+      b
+        .matchFieldsByQuery('rx')
+        .overrideColor({
+          mode: 'shades',
+          fixedColor: `super-light-${color}`,
+        })
+        .overrideCustomFieldConfig('fillOpacity', 10),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsByQuery('tx')
+        .overrideColor({
+          mode: 'shades',
+          fixedColor: `dark-${color}`,
+        })
+        .overrideCustomFieldConfig('fillOpacity', 10),
+    )
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel title={title} menu={menu} viz={viz} dataProvider={dataProvider} />
+  );
+}

--- a/src/components/metrics/workloads/WorkloadPage.tsx
+++ b/src/components/metrics/workloads/WorkloadPage.tsx
@@ -20,6 +20,7 @@ import { WorkloadPageOverview } from './WorkloadPageOverview';
 import { queries, variableQuery } from '../queries';
 import { WorkloadPageMemory } from './WorkloadPageMemory';
 import { WorkloadPageCPU } from './WorkloadPageCPU';
+import { WorkloadPageNetwork } from './WorkloadPageNetwork';
 
 export function WorkloadPage() {
   const styles = useStyles2(getStyles);
@@ -200,6 +201,7 @@ export function WorkloadPage() {
                         )}
                         {activeTab === 'cpu' && <WorkloadPageCPU />}
                         {activeTab === 'memory' && <WorkloadPageMemory />}
+                        {activeTab === 'network' && <WorkloadPageNetwork />}
                       </PluginPage>
                     </QueryVariable>
                   </CustomVariable>

--- a/src/components/metrics/workloads/WorkloadPageNetwork.tsx
+++ b/src/components/metrics/workloads/WorkloadPageNetwork.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesNetwork } from '../shared/TimeSeriesNetwork';
+
+export function WorkloadPageNetwork() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="node" />
+        <VariableControl name="namespace" />
+        <VariableControl name="pod" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesNetwork
+          title="Network Bandwidth"
+          unit="binBps"
+          color="blue"
+          rxExpr={queries.workloads.networkBandwidthRx}
+          txExpr={queries.workloads.networkBandwidthTx}
+          rxLegend="Rx"
+          txLegend="Tx"
+        />
+        <TimeSeriesNetwork
+          title="Network Saturation"
+          unit="pps"
+          color="red"
+          rxExpr={queries.workloads.networkSaturationRx}
+          txExpr={queries.workloads.networkSaturationTx}
+          rxLegend="Rx dropped packets"
+          txLegend="Tx dropped packets"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesNetwork
+          title="Network Bandwidth by Pod"
+          unit="binBps"
+          color="blue"
+          rxExpr={queries.workloads.networkBandwidthByPodRx}
+          txExpr={queries.workloads.networkBandwidthByPodTx}
+          rxLegend="Rx ({{pod}})"
+          txLegend="Tx ({{pod}})"
+        />
+        <TimeSeriesNetwork
+          title="Network Saturation by Pod"
+          unit="pps"
+          color="red"
+          rxExpr={queries.workloads.networkSaturationByPodRx}
+          txExpr={queries.workloads.networkSaturationByPodTx}
+          rxLegend="Rx dropped packets ({{pod}})"
+          txLegend="Tx dropped packets ({{pod}})"
+        />
+      </div>
+    </Stack>
+  );
+}


### PR DESCRIPTION
This commit adds the details metrics for network usage of nodes,
namespaces, workloads and pods. For each resource the following
information are added:
- Network bandwidth
- Network saturation
- Network bandwidth and saturation distributed by child resources
