### PR TITLE
Add Storage Details Metrics

### DIFF
--- a/src/components/metrics/namespaces/NamespacePage.tsx
+++ b/src/components/metrics/namespaces/NamespacePage.tsx
@@ -21,6 +21,7 @@ import { NamespacePageOverview } from './NamespacePageOverview';
 import { NamespacePageCPU } from './NamespacePageCPU';
 import { NamespacePageMemory } from './NamespacePageMemory';
 import { NamespacePageNetwork } from './NamespacePageNetwork';
+import { NamespacePageStorage } from './NamespacePageStorage';
 
 export function NamespacePage() {
   const styles = useStyles2(getStyles);
@@ -167,6 +168,7 @@ export function NamespacePage() {
                   {activeTab === 'cpu' && <NamespacePageCPU />}
                   {activeTab === 'memory' && <NamespacePageMemory />}
                   {activeTab === 'network' && <NamespacePageNetwork />}
+                  {activeTab === 'storage' && <NamespacePageStorage />}
                 </PluginPage>
               </QueryVariable>
             </CustomVariable>

--- a/src/components/metrics/namespaces/NamespacePageNetwork.tsx
+++ b/src/components/metrics/namespaces/NamespacePageNetwork.tsx
@@ -4,7 +4,7 @@ import { VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
-import { TimeSeriesNetwork } from '../shared/TimeSeriesNetwork';
+import { TimeSeriesIO } from '../shared/TimeSeriesIO';
 
 export function NamespacePageNetwork() {
   const styles = useStyles2(getStyles);
@@ -21,43 +21,43 @@ export function NamespacePageNetwork() {
       </div>
 
       <div className={styles.dashboard.row.height400px}>
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Bandwidth"
           unit="binBps"
           color="blue"
-          rxExpr={queries.namespaces.networkBandwidthRx}
-          txExpr={queries.namespaces.networkBandwidthTx}
-          rxLegend="Rx"
-          txLegend="Tx"
+          inExpr={queries.namespaces.networkBandwidthRx}
+          outExpr={queries.namespaces.networkBandwidthTx}
+          inLegend="Rx"
+          outLegend="Tx"
         />
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Saturation"
           unit="pps"
           color="red"
-          rxExpr={queries.namespaces.networkSaturationRx}
-          txExpr={queries.namespaces.networkSaturationTx}
-          rxLegend="Rx dropped packets"
-          txLegend="Tx dropped packets"
+          inExpr={queries.namespaces.networkSaturationRx}
+          outExpr={queries.namespaces.networkSaturationTx}
+          inLegend="Rx dropped packets"
+          outLegend="Tx dropped packets"
         />
       </div>
       <div className={styles.dashboard.row.height400px}>
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Bandwidth by Workload"
           unit="binBps"
           color="blue"
-          rxExpr={queries.namespaces.networkBandwidthByWorkloadRx}
-          txExpr={queries.namespaces.networkBandwidthByWorkloadTx}
-          rxLegend="Rx ({{workload_type}}/{{workload}})"
-          txLegend="Tx ({{workload_type}}/{{workload}})"
+          inExpr={queries.namespaces.networkBandwidthByWorkloadRx}
+          outExpr={queries.namespaces.networkBandwidthByWorkloadTx}
+          inLegend="Rx ({{workload_type}}/{{workload}})"
+          outLegend="Tx ({{workload_type}}/{{workload}})"
         />
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Saturation by Workload"
           unit="pps"
           color="red"
-          rxExpr={queries.namespaces.networkSaturationByWorkloadRx}
-          txExpr={queries.namespaces.networkSaturationByWorkloadTx}
-          rxLegend="Rx dropped packets ({{workload_type}}/{{workload}})"
-          txLegend="Tx dropped packets ({{workload_type}}/{{workload}})"
+          inExpr={queries.namespaces.networkSaturationByWorkloadRx}
+          outExpr={queries.namespaces.networkSaturationByWorkloadTx}
+          inLegend="Rx dropped packets ({{workload_type}}/{{workload}})"
+          outLegend="Tx dropped packets ({{workload_type}}/{{workload}})"
         />
       </div>
     </Stack>

--- a/src/components/metrics/namespaces/NamespacePageStorage.tsx
+++ b/src/components/metrics/namespaces/NamespacePageStorage.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesIO } from '../shared/TimeSeriesIO';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+
+export function NamespacePageStorage() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="namespace" />
+        <VariableControl name="workload" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesIO
+          title="Throughput"
+          unit="Bps"
+          color="purple"
+          inExpr={queries.namespaces.throughputRead}
+          outExpr={queries.namespaces.throughputWrite}
+          inLegend="read"
+          outLegend="write"
+        />
+        <TimeSeriesIO
+          title="IOPS"
+          unit="iops"
+          color="blue"
+          inExpr={queries.namespaces.iopsRead}
+          outExpr={queries.namespaces.iopsWrite}
+          inLegend="read"
+          outLegend="write"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesIO
+          title="Throughput by Workload"
+          unit="Bps"
+          color="purple"
+          inExpr={queries.workloads.throughputRead}
+          outExpr={queries.workloads.throughputWrite}
+          inLegend="read ({{workload_type}}/{{workload}})"
+          outLegend="write ({{workload_type}}/{{workload}})"
+        />
+        <TimeSeriesIO
+          title="IOPS by Workload"
+          unit="iops"
+          color="blue"
+          inExpr={queries.workloads.iopsRead}
+          outExpr={queries.workloads.iopsWrite}
+          inLegend="read ({{workload_type}}/{{workload}})"
+          outLegend="write ({{workload_type}}/{{workload}})"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Waiting"
+          unit="s"
+          expr={queries.workloads.ioPressureWaiting}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Stalled"
+          unit="s"
+          expr={queries.workloads.ioPressureStalled}
+          legend="{{ workload_type }}/{{ workload }}"
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/nodes/NodePage.tsx
+++ b/src/components/metrics/nodes/NodePage.tsx
@@ -21,6 +21,7 @@ import { NodePageOverview } from './NodePageOverview';
 import { NodePageCPU } from './NodePageCPU';
 import { NodePageMemory } from './NodePageMemory';
 import { NodePageNetwork } from './NodePageNetwork';
+import { NodePageStorage } from './NodePageStorage';
 
 export function NodePage() {
   const styles = useStyles2(getStyles);
@@ -170,6 +171,7 @@ export function NodePage() {
                     {activeTab === 'cpu' && <NodePageCPU />}
                     {activeTab === 'memory' && <NodePageMemory />}
                     {activeTab === 'network' && <NodePageNetwork />}
+                    {activeTab === 'storage' && <NodePageStorage />}
                   </PluginPage>
                 </QueryVariable>
               </CustomVariable>

--- a/src/components/metrics/nodes/NodePageNetwork.tsx
+++ b/src/components/metrics/nodes/NodePageNetwork.tsx
@@ -4,7 +4,7 @@ import { VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
-import { TimeSeriesNetwork } from '../shared/TimeSeriesNetwork';
+import { TimeSeriesIO } from '../shared/TimeSeriesIO';
 
 export function NodePageNetwork() {
   const styles = useStyles2(getStyles);
@@ -22,43 +22,43 @@ export function NodePageNetwork() {
       </div>
 
       <div className={styles.dashboard.row.height400px}>
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Bandwidth"
           unit="binBps"
           color="blue"
-          rxExpr={queries.nodes.networkBandwidthRx}
-          txExpr={queries.nodes.networkBandwidthTx}
-          rxLegend="Rx"
-          txLegend="Tx"
+          inExpr={queries.nodes.networkBandwidthRx}
+          outExpr={queries.nodes.networkBandwidthTx}
+          inLegend="Rx"
+          outLegend="Tx"
         />
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Saturation"
           unit="pps"
           color="red"
-          rxExpr={queries.nodes.networkSaturationRx}
-          txExpr={queries.nodes.networkSaturationTx}
-          rxLegend="Rx dropped packets"
-          txLegend="Tx dropped packets"
+          inExpr={queries.nodes.networkSaturationRx}
+          outExpr={queries.nodes.networkSaturationTx}
+          inLegend="Rx dropped packets"
+          outLegend="Tx dropped packets"
         />
       </div>
       <div className={styles.dashboard.row.height400px}>
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Bandwidth by Pod"
           unit="binBps"
           color="blue"
-          rxExpr={queries.nodes.networkBandwidthByPodRx}
-          txExpr={queries.nodes.networkBandwidthByPodTx}
-          rxLegend="Rx ({{namespace}}/{{pod}})"
-          txLegend="Tx ({{namespace}}/{{pod}})"
+          inExpr={queries.nodes.networkBandwidthByPodRx}
+          outExpr={queries.nodes.networkBandwidthByPodTx}
+          inLegend="Rx ({{namespace}}/{{pod}})"
+          outLegend="Tx ({{namespace}}/{{pod}})"
         />
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Saturation by Pod"
           unit="pps"
           color="red"
-          rxExpr={queries.nodes.networkSaturationByPodRx}
-          txExpr={queries.nodes.networkSaturationByPodTx}
-          rxLegend="Rx dropped packets ({{namespace}}/{{pod}})"
-          txLegend="Tx dropped packets ({{namespace}}/{{pod}})"
+          inExpr={queries.nodes.networkSaturationByPodRx}
+          outExpr={queries.nodes.networkSaturationByPodTx}
+          inLegend="Rx dropped packets ({{namespace}}/{{pod}})"
+          outLegend="Tx dropped packets ({{namespace}}/{{pod}})"
         />
       </div>
     </Stack>

--- a/src/components/metrics/nodes/NodePageStorage.tsx
+++ b/src/components/metrics/nodes/NodePageStorage.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesIO } from '../shared/TimeSeriesIO';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+
+export function NodePageStorage() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="node" />
+        <VariableControl name="namespace" />
+        <VariableControl name="pod" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesIO
+          title="Throughput"
+          unit="Bps"
+          color="purple"
+          inExpr={queries.nodes.throughputRead}
+          outExpr={queries.nodes.throughputWrite}
+          inLegend="read"
+          outLegend="write"
+        />
+        <TimeSeriesIO
+          title="IOPS"
+          unit="iops"
+          color="blue"
+          inExpr={queries.nodes.iopsRead}
+          outExpr={queries.nodes.iopsWrite}
+          inLegend="read"
+          outLegend="write"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesIO
+          title="Throughput by Pod"
+          unit="Bps"
+          color="purple"
+          inExpr={queries.pods.throughputRead}
+          outExpr={queries.pods.throughputWrite}
+          inLegend="read ({{namespace}}/{{pod}})"
+          outLegend="write ({{namespace}}/{{pod}})"
+        />
+        <TimeSeriesIO
+          title="IOPS by Pod"
+          unit="iops"
+          color="blue"
+          inExpr={queries.pods.iopsRead}
+          outExpr={queries.pods.iopsWrite}
+          inLegend="read ({{namespace}}/{{pod}})"
+          outLegend="write ({{namespace}}/{{pod}})"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Waiting"
+          unit="s"
+          expr={queries.pods.ioPressureWaiting}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Stalled"
+          unit="s"
+          expr={queries.pods.ioPressureStalled}
+          legend="{{ namespace }}/{{ pod }}"
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/pods/PodPage.tsx
+++ b/src/components/metrics/pods/PodPage.tsx
@@ -20,6 +20,7 @@ import { PodPageOverview } from './PodPageOverview';
 import { PodPageCPU } from './PodPageCPU';
 import { PodPageMemory } from './PodPageMemory';
 import { PodPageNetwork } from './PodPageNetwork';
+import { PodPageStorage } from './PodPageStorage';
 
 export function PodPage() {
   const styles = useStyles2(getStyles);
@@ -73,90 +74,99 @@ export function PodPage() {
             hide={VariableHide.hideVariable}
           >
             <CustomVariable
-              name="namespace"
-              label="Namespace"
-              query={namespace}
-              initialValue={namespace}
+              name="node"
+              label="Node"
+              query=".+"
+              initialValue=".+"
               hide={VariableHide.hideVariable}
             >
               <CustomVariable
-                name="pod"
-                label="Pod"
-                query={pod}
-                initialValue={pod}
+                name="namespace"
+                label="Namespace"
+                query={namespace}
+                initialValue={namespace}
                 hide={VariableHide.hideVariable}
               >
-                <PluginPage
-                  renderTitle={() => (
-                    <Stack gap={0} alignItems="center" direction="row">
-                      <img
-                        className={styles.pluginPage.title.image}
-                        alt={pod}
-                        src={resourcesImg}
-                      />
-                      <h1>{pod}</h1>
-                      <Badge
-                        className={styles.pluginPage.title.badge}
-                        color="blue"
-                        text="pod"
-                      />
-                    </Stack>
-                  )}
-                  subTitle={pluginJson.info.description}
-                  actions={
-                    <>
-                      <TimeRangePicker />
-                      <RefreshPicker />
-                    </>
-                  }
+                <CustomVariable
+                  name="pod"
+                  label="Pod"
+                  query={pod}
+                  initialValue={pod}
+                  hide={VariableHide.hideVariable}
                 >
-                  <TabsBar className={styles.dashboard.tabsBar}>
-                    <Tab
-                      label="Overview"
-                      active={activeTab === 'overview'}
-                      onChangeTab={(ev) => {
-                        ev?.preventDefault();
-                        setActiveTab('overview');
-                      }}
-                    />
-                    <Tab
-                      label="CPU"
-                      active={activeTab === 'cpu'}
-                      onChangeTab={(ev) => {
-                        ev?.preventDefault();
-                        setActiveTab('cpu');
-                      }}
-                    />
-                    <Tab
-                      label="Memory"
-                      active={activeTab === 'memory'}
-                      onChangeTab={(ev) => {
-                        ev?.preventDefault();
-                        setActiveTab('memory');
-                      }}
-                    />
-                    <Tab
-                      label="Network"
-                      active={activeTab === 'network'}
-                      onChangeTab={(ev) => {
-                        ev?.preventDefault();
-                        setActiveTab('network');
-                      }}
-                    />
-                    <Tab
-                      label="Storage"
-                      active={activeTab === 'storage'}
-                      onChangeTab={(ev) => {
-                        ev?.preventDefault();
-                        setActiveTab('storage');
-                      }}
-                    />
-                  </TabsBar>
-                  {activeTab === 'overview' && <PodPageOverview />}
-                  {activeTab === 'cpu' && <PodPageCPU />}
-                  {activeTab === 'memory' && <PodPageMemory />}
-                  {activeTab === 'network' && <PodPageNetwork />}
-                </PluginPage>
+                  <PluginPage
+                    renderTitle={() => (
+                      <Stack gap={0} alignItems="center" direction="row">
+                        <img
+                          className={styles.pluginPage.title.image}
+                          alt={pod}
+                          src={resourcesImg}
+                        />
+                        <h1>{pod}</h1>
+                        <Badge
+                          className={styles.pluginPage.title.badge}
+                          color="blue"
+                          text="pod"
+                        />
+                      </Stack>
+                    )}
+                    subTitle={pluginJson.info.description}
+                    actions={
+                      <>
+                        <TimeRangePicker />
+                        <RefreshPicker />
+                      </>
+                    }
+                  >
+                    <TabsBar className={styles.dashboard.tabsBar}>
+                      <Tab
+                        label="Overview"
+                        active={activeTab === 'overview'}
+                        onChangeTab={(ev) => {
+                          ev?.preventDefault();
+                          setActiveTab('overview');
+                        }}
+                      />
+                      <Tab
+                        label="CPU"
+                        active={activeTab === 'cpu'}
+                        onChangeTab={(ev) => {
+                          ev?.preventDefault();
+                          setActiveTab('cpu');
+                        }}
+                      />
+                      <Tab
+                        label="Memory"
+                        active={activeTab === 'memory'}
+                        onChangeTab={(ev) => {
+                          ev?.preventDefault();
+                          setActiveTab('memory');
+                        }}
+                      />
+                      <Tab
+                        label="Network"
+                        active={activeTab === 'network'}
+                        onChangeTab={(ev) => {
+                          ev?.preventDefault();
+                          setActiveTab('network');
+                        }}
+                      />
+                      <Tab
+                        label="Storage"
+                        active={activeTab === 'storage'}
+                        onChangeTab={(ev) => {
+                          ev?.preventDefault();
+                          setActiveTab('storage');
+                        }}
+                      />
+                    </TabsBar>
+                    {activeTab === 'overview' && <PodPageOverview />}
+                    {activeTab === 'cpu' && <PodPageCPU />}
+                    {activeTab === 'memory' && <PodPageMemory />}
+                    {activeTab === 'network' && <PodPageNetwork />}
+                    {activeTab === 'storage' && <PodPageStorage />}
+                  </PluginPage>
+                </CustomVariable>
               </CustomVariable>
             </CustomVariable>
           </QueryVariable>

--- a/src/components/metrics/pods/PodPageNetwork.tsx
+++ b/src/components/metrics/pods/PodPageNetwork.tsx
@@ -4,7 +4,7 @@ import { VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
-import { TimeSeriesNetwork } from '../shared/TimeSeriesNetwork';
+import { TimeSeriesIO } from '../shared/TimeSeriesIO';
 
 export function PodPageNetwork() {
   const styles = useStyles2(getStyles);
@@ -20,43 +20,43 @@ export function PodPageNetwork() {
       </div>
 
       <div className={styles.dashboard.row.height400px}>
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Bandwidth"
           unit="binBps"
           color="blue"
-          rxExpr={queries.pods.networkBandwidthRx}
-          txExpr={queries.pods.networkBandwidthTx}
-          rxLegend="Rx"
-          txLegend="Tx"
+          inExpr={queries.pods.networkBandwidthRx}
+          outExpr={queries.pods.networkBandwidthTx}
+          inLegend="Rx"
+          outLegend="Tx"
         />
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Saturation"
           unit="pps"
           color="red"
-          rxExpr={queries.pods.networkSaturationRx}
-          txExpr={queries.pods.networkSaturationTx}
-          rxLegend="Rx dropped packets"
-          txLegend="Tx dropped packets"
+          inExpr={queries.pods.networkSaturationRx}
+          outExpr={queries.pods.networkSaturationTx}
+          inLegend="Rx dropped packets"
+          outLegend="Tx dropped packets"
         />
       </div>
       <div className={styles.dashboard.row.height400px}>
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Bandwidth by Interface"
           unit="binBps"
           color="blue"
-          rxExpr={queries.pods.networkBandwidthByInterfaceRx}
-          txExpr={queries.pods.networkBandwidthByInterfaceTx}
-          rxLegend="Rx ({{interface}})"
-          txLegend="Tx ({{interface}})"
+          inExpr={queries.pods.networkBandwidthByInterfaceRx}
+          outExpr={queries.pods.networkBandwidthByInterfaceTx}
+          inLegend="Rx ({{interface}})"
+          outLegend="Tx ({{interface}})"
         />
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Saturation by Interface"
           unit="pps"
           color="red"
-          rxExpr={queries.pods.networkSaturationByInterfaceRx}
-          txExpr={queries.pods.networkSaturationByInterfaceTx}
-          rxLegend="Rx dropped packets ({{interface}})"
-          txLegend="Tx dropped packets ({{interface}})"
+          inExpr={queries.pods.networkSaturationByInterfaceRx}
+          outExpr={queries.pods.networkSaturationByInterfaceTx}
+          inLegend="Rx dropped packets ({{interface}})"
+          outLegend="Tx dropped packets ({{interface}})"
         />
       </div>
     </Stack>

--- a/src/components/metrics/pods/PodPageStorage.tsx
+++ b/src/components/metrics/pods/PodPageStorage.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesIO } from '../shared/TimeSeriesIO';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+
+export function PodPageStorage() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="namespace" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesIO
+          title="Throughput"
+          unit="Bps"
+          color="purple"
+          inExpr={queries.pods.throughputRead}
+          outExpr={queries.pods.throughputWrite}
+          inLegend="read"
+          outLegend="write"
+        />
+        <TimeSeriesIO
+          title="IOPS"
+          unit="iops"
+          color="blue"
+          inExpr={queries.pods.iopsRead}
+          outExpr={queries.pods.iopsWrite}
+          inLegend="read"
+          outLegend="write"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesIO
+          title="Throughput by Container"
+          unit="Bps"
+          color="purple"
+          inExpr={queries.containers.throughputRead}
+          outExpr={queries.containers.throughputWrite}
+          inLegend="read ({{container}})"
+          outLegend="write ({{container}})"
+        />
+        <TimeSeriesIO
+          title="IOPS by Container"
+          unit="iops"
+          color="blue"
+          inExpr={queries.containers.iopsRead}
+          outExpr={queries.containers.iopsWrite}
+          inLegend="read ({{container}})"
+          outLegend="write ({{container}})"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Container Waiting"
+          unit="s"
+          expr={queries.containers.ioPressureWaiting}
+          legend="{{ container }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Container Stalled"
+          unit="s"
+          expr={queries.containers.ioPressureStalled}
+          legend="{{ container }}"
+        />
+      </div>
+    </Stack>
+  );
+}

--- a/src/components/metrics/queries.ts
+++ b/src/components/metrics/queries.ts
@@ -866,6 +866,50 @@ sum(
     )
   ) by(cluster,namespace,pod,interface)
 ) by(cluster,namespace,pod)`,
+    throughputRead: `sum(
+  rate(
+    container_fs_reads_bytes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node"
+    }[$__rate_interval]
+  )
+) by(node)`,
+    throughputWrite: `-sum(
+  rate(
+    container_fs_writes_bytes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node"
+    }[$__rate_interval]
+  )
+) by(node)`,
+    iopsRead: `sum(
+  rate(
+    container_fs_reads_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node"
+    }[$__rate_interval]
+  )
+) by(node)`,
+    iopsWrite: `-sum(
+  rate(
+    container_fs_writes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node"
+    }[$__rate_interval]
+  )
+) by(node)`,
   },
   namespaces: {
     labelsByCluster: `label_values(kube_namespace_status_phase{cluster=~"$cluster"}, namespace)`,
@@ -1249,6 +1293,50 @@ sum(
     ) by(cluster,namespace,workload,workload_type,pod)
   ) by(cluster,namespace,pod)
 ) by(cluster,namespace,workload,workload_type)`,
+    throughputRead: `sum(
+  rate(
+    container_fs_reads_bytes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      namespace=~"$namespace"
+    }[$__rate_interval]
+  )
+) by(namespace)`,
+    throughputWrite: `-sum(
+  rate(
+    container_fs_writes_bytes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      namespace=~"$namespace"
+    }[$__rate_interval]
+  )
+) by(namespace)`,
+    iopsRead: `sum(
+  rate(
+    container_fs_reads_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      namespace=~"$namespace"
+    }[$__rate_interval]
+  )
+) by(namespace)`,
+    iopsWrite: `-sum(
+  rate(
+    container_fs_writes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      namespace=~"$namespace"
+    }[$__rate_interval]
+  )
+) by(namespace)`,
   },
   workloads: {
     labelsByClusterNamespace: `query_result(
@@ -3215,6 +3303,110 @@ label_join(
     )
   ) by(cluster,namespace,pod,interface)
 ) by(cluster,namespace,pod)`,
+    throughputRead: `sum(
+  sum(
+    sum(
+      rate(
+        container_fs_reads_bytes_total{
+          container!="POD",
+          container!="",
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"
+        }[$__rate_interval]
+      )
+    ) by(cluster,namespace,pod)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    topk(
+      1,
+      group(
+        namespace_workload_pod:kube_pod_owner:relabel{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          workload=~"$workload"
+        }
+      ) by(cluster,namespace,workload,workload_type,pod)
+    ) by(cluster,namespace,pod)
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(workload,workload_type)`,
+    throughputWrite: `-sum(
+  sum(
+    sum(
+      rate(
+        container_fs_writes_bytes_total{
+          container!="POD",
+          container!="",
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"
+        }[$__rate_interval]
+      )
+    ) by(cluster,namespace,pod)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    topk(
+      1,
+      group(
+        namespace_workload_pod:kube_pod_owner:relabel{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          workload=~"$workload"
+        }
+      ) by(cluster,namespace,workload,workload_type,pod)
+    ) by(cluster,namespace,pod)
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(workload,workload_type)`,
+    iopsRead: `sum(
+  sum(
+    sum(
+      rate(
+        container_fs_reads_total{
+          container!="POD",
+          container!="",
+          cluster=~"$cluster",
+          device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+          namespace=~"$namespace"
+        }[$__rate_interval]
+      )
+    ) by(cluster,namespace,pod)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    topk(
+      1,
+      group(
+        namespace_workload_pod:kube_pod_owner:relabel{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          workload=~"$workload"
+        }
+      ) by(cluster,namespace,workload,workload_type,pod)
+    ) by(cluster,namespace,pod)
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(workload,workload_type)`,
+    iopsWrite: `-sum(
+  sum(
+    sum(
+      rate(
+        container_fs_writes_total{
+          container!="POD",
+          container!="",
+          cluster=~"$cluster",
+          device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+          namespace=~"$namespace"
+        }[$__rate_interval]
+      )
+    ) by(cluster,namespace,pod)
+      * on(cluster,namespace,pod) group_left(workload,workload_type)
+    topk(
+      1,
+      group(
+        namespace_workload_pod:kube_pod_owner:relabel{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          workload=~"$workload"
+        }
+      ) by(cluster,namespace,workload,workload_type,pod)
+    ) by(cluster,namespace,pod)
+  ) by(cluster,namespace,pod,workload,workload_type)
+) by(workload,workload_type)`,
   },
   pods: {
     count: `count(kube_pod_info{cluster=~"$cluster", namespace=~"$namespace", pod!=""})`,
@@ -3905,6 +4097,58 @@ sum(
     )
   ) by(cluster,namespace,pod,interface)
 ) by(interface)`,
+    throughputRead: `sum(
+  rate(
+    container_fs_reads_bytes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }[$__rate_interval]
+  )
+) by(namespace,pod)`,
+    throughputWrite: `-sum(
+  rate(
+    container_fs_writes_bytes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }[$__rate_interval]
+  )
+) by(namespace,pod)`,
+    iopsRead: `sum(
+  rate(
+    container_fs_reads_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }[$__rate_interval]
+  )
+) by(namespace,pod)`,
+    iopsWrite: `-sum(
+  rate(
+    container_fs_writes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }[$__rate_interval]
+  )
+) by(namespace,pod)`,
   },
   containers: {
     info: `last_over_time(
@@ -4435,6 +4679,58 @@ sum(
   "pod",
   "container"
 )`,
+    throughputRead: `sum(
+  rate(
+    container_fs_reads_bytes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }[$__rate_interval]
+  )
+) by(namespace,pod,container)`,
+    throughputWrite: `-sum(
+  rate(
+    container_fs_writes_bytes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }[$__rate_interval]
+  )
+) by(namespace,pod,container)`,
+    iopsRead: `sum(
+  rate(
+    container_fs_reads_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }[$__rate_interval]
+  )
+) by(namespace,pod,container)`,
+    iopsWrite: `-sum(
+  rate(
+    container_fs_writes_total{
+      container!="POD",
+      container!="",
+      cluster=~"$cluster",
+      device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",
+      node=~"$node",
+      namespace=~"$namespace",
+      pod=~"$pod"
+    }[$__rate_interval]
+  )
+) by(namespace,pod,container)`,
   },
   persistentVolumeClaims: {
     count: `count(

--- a/src/components/metrics/shared/TimeSeriesIO.tsx
+++ b/src/components/metrics/shared/TimeSeriesIO.tsx
@@ -7,35 +7,35 @@ import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
 
 interface Props {
   title: string;
-  unit: 'binBps' | 'pps';
-  color: 'blue' | 'red';
-  rxExpr: string;
-  txExpr: string;
-  rxLegend: string;
-  txLegend: string;
+  unit: 'Bps' | 'iops' | 'binBps' | 'pps';
+  color: 'blue' | 'purple' | 'red';
+  inExpr: string;
+  outExpr: string;
+  inLegend: string;
+  outLegend: string;
 }
 
-export function TimeSeriesNetwork({
+export function TimeSeriesIO({
   title,
   unit,
   color,
-  rxExpr,
-  txExpr,
-  rxLegend,
-  txLegend,
+  inExpr,
+  outExpr,
+  inLegend,
+  outLegend,
 }: Props) {
   const queries: SceneDataQuery[] = [
     {
-      refId: 'rx',
+      refId: 'in',
       format: 'time_series',
-      expr: rxExpr,
-      legendFormat: rxLegend,
+      expr: inExpr,
+      legendFormat: inLegend,
     },
     {
-      refId: 'tx',
+      refId: 'out',
       format: 'time_series',
-      expr: txExpr,
-      legendFormat: txLegend,
+      expr: outExpr,
+      legendFormat: outLegend,
     },
   ];
 
@@ -53,12 +53,13 @@ export function TimeSeriesNetwork({
       asTable: true,
       displayMode: LegendDisplayMode.Table,
       placement: 'bottom',
+      calcs: ['lastNotNull'],
     })
     .setCustomFieldConfig('axisSoftMin', -100)
     .setCustomFieldConfig('axisSoftMax', 100)
     .setOverrides((b) =>
       b
-        .matchFieldsByQuery('rx')
+        .matchFieldsByQuery('in')
         .overrideColor({
           mode: 'shades',
           fixedColor: `super-light-${color}`,
@@ -67,7 +68,7 @@ export function TimeSeriesNetwork({
     )
     .setOverrides((b) =>
       b
-        .matchFieldsByQuery('tx')
+        .matchFieldsByQuery('out')
         .overrideColor({
           mode: 'shades',
           fixedColor: `dark-${color}`,

--- a/src/components/metrics/shared/TimeSeriesMemoryOrCPUDistribution.tsx
+++ b/src/components/metrics/shared/TimeSeriesMemoryOrCPUDistribution.tsx
@@ -45,6 +45,7 @@ export function TimeSeriesMemoryOrCPUDistribution({
       asTable: true,
       displayMode: LegendDisplayMode.Table,
       placement: 'bottom',
+      calcs: ['p95'],
     })
     .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
     .setCustomFieldConfig('fillOpacity', 100)

--- a/src/components/metrics/shared/TimeSeriesMemoryOrCPUEfficiency.tsx
+++ b/src/components/metrics/shared/TimeSeriesMemoryOrCPUEfficiency.tsx
@@ -46,6 +46,7 @@ export function TimeSeriesMemoryOrCPUEfficiency({
       asTable: true,
       displayMode: LegendDisplayMode.Table,
       placement: 'bottom',
+      calcs: ['p95'],
     })
     .setColor({
       mode: FieldColorModeId.Shades,

--- a/src/components/metrics/workloads/WorkloadPage.tsx
+++ b/src/components/metrics/workloads/WorkloadPage.tsx
@@ -21,6 +21,7 @@ import { queries, variableQuery } from '../queries';
 import { WorkloadPageMemory } from './WorkloadPageMemory';
 import { WorkloadPageCPU } from './WorkloadPageCPU';
 import { WorkloadPageNetwork } from './WorkloadPageNetwork';
+import { WorkloadPageStorage } from './WorkloadPageStorage';
 
 export function WorkloadPage() {
   const styles = useStyles2(getStyles);
@@ -202,6 +203,7 @@ export function WorkloadPage() {
                         {activeTab === 'cpu' && <WorkloadPageCPU />}
                         {activeTab === 'memory' && <WorkloadPageMemory />}
                         {activeTab === 'network' && <WorkloadPageNetwork />}
+                        {activeTab === 'storage' && <WorkloadPageStorage />}
                       </PluginPage>
                     </QueryVariable>
                   </CustomVariable>

--- a/src/components/metrics/workloads/WorkloadPageNetwork.tsx
+++ b/src/components/metrics/workloads/WorkloadPageNetwork.tsx
@@ -4,7 +4,7 @@ import { VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
-import { TimeSeriesNetwork } from '../shared/TimeSeriesNetwork';
+import { TimeSeriesIO } from '../shared/TimeSeriesIO';
 
 export function WorkloadPageNetwork() {
   const styles = useStyles2(getStyles);
@@ -22,43 +22,43 @@ export function WorkloadPageNetwork() {
       </div>
 
       <div className={styles.dashboard.row.height400px}>
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Bandwidth"
           unit="binBps"
           color="blue"
-          rxExpr={queries.workloads.networkBandwidthRx}
-          txExpr={queries.workloads.networkBandwidthTx}
-          rxLegend="Rx"
-          txLegend="Tx"
+          inExpr={queries.workloads.networkBandwidthRx}
+          outExpr={queries.workloads.networkBandwidthTx}
+          inLegend="Rx"
+          outLegend="Tx"
         />
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Saturation"
           unit="pps"
           color="red"
-          rxExpr={queries.workloads.networkSaturationRx}
-          txExpr={queries.workloads.networkSaturationTx}
-          rxLegend="Rx dropped packets"
-          txLegend="Tx dropped packets"
+          inExpr={queries.workloads.networkSaturationRx}
+          outExpr={queries.workloads.networkSaturationTx}
+          inLegend="Rx dropped packets"
+          outLegend="Tx dropped packets"
         />
       </div>
       <div className={styles.dashboard.row.height400px}>
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Bandwidth by Pod"
           unit="binBps"
           color="blue"
-          rxExpr={queries.workloads.networkBandwidthByPodRx}
-          txExpr={queries.workloads.networkBandwidthByPodTx}
-          rxLegend="Rx ({{pod}})"
-          txLegend="Tx ({{pod}})"
+          inExpr={queries.workloads.networkBandwidthByPodRx}
+          outExpr={queries.workloads.networkBandwidthByPodTx}
+          inLegend="Rx ({{pod}})"
+          outLegend="Tx ({{pod}})"
         />
-        <TimeSeriesNetwork
+        <TimeSeriesIO
           title="Network Saturation by Pod"
           unit="pps"
           color="red"
-          rxExpr={queries.workloads.networkSaturationByPodRx}
-          txExpr={queries.workloads.networkSaturationByPodTx}
-          rxLegend="Rx dropped packets ({{pod}})"
-          txLegend="Tx dropped packets ({{pod}})"
+          inExpr={queries.workloads.networkSaturationByPodRx}
+          outExpr={queries.workloads.networkSaturationByPodTx}
+          inLegend="Rx dropped packets ({{pod}})"
+          outLegend="Tx dropped packets ({{pod}})"
         />
       </div>
     </Stack>

--- a/src/components/metrics/workloads/WorkloadPageStorage.tsx
+++ b/src/components/metrics/workloads/WorkloadPageStorage.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { TimeSeriesIO } from '../shared/TimeSeriesIO';
+import { TimeSeriesMemoryOrCPUDistribution } from '../shared/TimeSeriesMemoryOrCPUDistribution';
+
+export function WorkloadPageStorage() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="node" />
+        <VariableControl name="namespace" />
+        <VariableControl name="pod" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesIO
+          title="Throughput"
+          unit="Bps"
+          color="purple"
+          inExpr={queries.workloads.throughputRead}
+          outExpr={queries.workloads.throughputWrite}
+          inLegend="read"
+          outLegend="write"
+        />
+        <TimeSeriesIO
+          title="IOPS"
+          unit="iops"
+          color="blue"
+          inExpr={queries.workloads.iopsRead}
+          outExpr={queries.workloads.iopsWrite}
+          inLegend="read"
+          outLegend="write"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesIO
+          title="Throughput by Pod"
+          unit="Bps"
+          color="purple"
+          inExpr={queries.pods.throughputRead}
+          outExpr={queries.pods.throughputWrite}
+          inLegend="read ({{pod}})"
+          outLegend="write ({{pod}})"
+        />
+        <TimeSeriesIO
+          title="IOPS by Pod"
+          unit="iops"
+          color="blue"
+          inExpr={queries.pods.iopsRead}
+          outExpr={queries.pods.iopsWrite}
+          inLegend="read ({{pod}})"
+          outLegend="write ({{pod}})"
+        />
+      </div>
+      <div className={styles.dashboard.row.height400px}>
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Waiting"
+          unit="s"
+          expr={queries.pods.ioPressureWaiting}
+          legend="{{ pod }}"
+        />
+        <TimeSeriesMemoryOrCPUDistribution
+          title="Pressure: Pod Stalled"
+          unit="s"
+          expr={queries.pods.ioPressureStalled}
+          legend="{{ pod }}"
+        />
+      </div>
+    </Stack>
+  );
+}


### PR DESCRIPTION
This commit adds the details metrics for storage usage of nodes,
namespaces, workloads and pods. For each resource the following
information are added:
- Throughput (read/write)
- IOPS (read/write)
- Thoughput and IOPS distributed by child resources
- PSI metrics distributed by child resources
