### PR TITLE
Add Logs to Metrics Pages

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
       GF_LOG_FILTERS: plugin.ricoberger-kubernetes-datasource:debug
       GF_LOG_LEVEL: error
       GF_AUTH_BASIC_ENABLED: true
+      GF_PLUGINS_PREINSTALL_SYNC: victoriametrics-logs-datasource
     volumes:
       - ./kubeconfig.yaml:/kubeconfig.yaml
     extra_hosts:

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -27,6 +27,7 @@ type PluginSettings struct {
 	GenerateKubeconfigRedirectUrls   []string              `json:"generateKubeconfigRedirectUrls"`
 	IntegrationsMetricsDatasourceUid string                `json:"integrationsMetricsDatasourceUid"`
 	IntegrationsMetricsClusterLabel  string                `json:"integrationsMetricsClusterLabel"`
+	IntegrationsMetricsLogs          string                `json:"integrationsMetricsLogs"`
 	IntegrationsTracesQuery          string                `json:"integrationsTracesQuery"`
 	Secrets                          *SecretPluginSettings `json:"-"`
 }

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -47,6 +47,8 @@ func (d *Datasource) handleSettings(ctx context.Context, query concurrent.Query)
 		setting = config.IntegrationsMetricsDatasourceUid
 	case "integrationsMetricsClusterLabel":
 		setting = config.IntegrationsMetricsClusterLabel
+	case "integrationsMetricsLogs":
+		setting = config.IntegrationsMetricsLogs
 	default:
 	}
 

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -22,15 +22,86 @@ datasources:
       generateKubeconfigPort: 11716
       generateKubeconfigRedirectUrls:
         - http://localhost:11716
-      integrationsMetricsDatasourceUid: prometheus
+      integrationsMetricsDatasourceUid: victoriametrics
       integrationsMetricsClusterLabel: '.*'
+      integrationsMetricsLogs: |
+        {
+          "pod": {
+            "datasource": {
+              "type": "victoriametrics-logs-datasource",
+              "uid": "victorialogs"
+            },
+            "queries": [
+              {
+                "refId": "A",
+                "expr": "k8s.pod.name:=\"$${pod}\" | sort by (_time) desc",
+                "queryType": "instant",
+                "maxLines": 1000
+              }
+            ]
+          },
+          "workload": {
+            "datasource": {
+              "type": "victoriametrics-logs-datasource",
+              "uid": "victorialogs"
+            },
+            "queries": [
+              {
+                "refId": "A",
+                "expr": "k8s.pod.name:in($${pod}) | sort by (_time) desc",
+                "queryType": "instant",
+                "maxLines": 1000
+              }
+            ]
+          },
+          "namespace": {
+            "datasource": {
+              "type": "victoriametrics-logs-datasource",
+              "uid": "victorialogs"
+            },
+            "queries": [
+              {
+                "refId": "A",
+                "expr": "k8s.namespace.name:=\"$${namespace}\" | sort by (_time) desc",
+                "queryType": "instant",
+                "maxLines": 1000
+              }
+            ]
+          },
+          "node": {
+            "datasource": {
+              "type": "victoriametrics-logs-datasource",
+              "uid": "victorialogs"
+            },
+            "queries": [
+              {
+                "refId": "A",
+                "expr": "k8s.node.name:=\"$${node}\" | sort by (_time) desc",
+                "queryType": "instant",
+                "maxLines": 1000
+              }
+            ]
+          }
+        }
       integrationsTracesQuery: '{"datasource":"jaeger","queries":[{"query":"$${__value.raw}","refId":"A"}]}'
     secureJsonData:
       clusterKubeconfig:
       grafanaPassword: admin
 
-  - name: Prometheus
+  - name: VictoriaMetrics
     type: prometheus
-    uid: prometheus
+    uid: victoriametrics
     url: http://host.docker.internal:8481/select/0/prometheus
+    access: proxy
+
+  - name: VictoriaLogs
+    type: victoriametrics-logs-datasource
+    uid: victorialogs
+    url: http://host.docker.internal:9471
+    access: proxy
+
+  - name: VictoriaTraces
+    type: jaeger
+    uid: victoriatraces
+    url: http://host.docker.internal:10471/select/jaeger
     access: proxy

--- a/src/components/metrics/namespaces/NamespacePage.tsx
+++ b/src/components/metrics/namespaces/NamespacePage.tsx
@@ -24,6 +24,8 @@ import { NamespacePageNetwork } from './NamespacePageNetwork';
 import { NamespacePageStorage } from './NamespacePageStorage';
 import { ROUTES } from '../../../constants';
 import { prefixRoute } from '../../../utils/utils.routing';
+import { TabLogsContent } from '../shared/TabLogsContent';
+import { TabLogs } from '../shared/TabLogs';
 
 export function NamespacePage() {
   const styles = useStyles2(getStyles);
@@ -72,144 +74,172 @@ export function NamespacePage() {
             refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
-            <CustomVariable
-              name="namespace"
-              label="Namespace"
-              query={namespace}
-              initialValue={namespace}
+            <QueryVariable
+              name="logs"
+              label="Logs"
+              datasource={{ type: datasourcePluginJson.id, uid: '$datasource' }}
+              query={{
+                refId: 'settings',
+                queryType: 'settings',
+                setting: 'integrationsMetricsLogs',
+                variableField: 'values',
+              }}
+              refresh={VariableRefresh.onDashboardLoad}
               hide={VariableHide.hideVariable}
             >
-              <QueryVariable
-                name="workload"
-                label="Workload"
-                datasource={{
-                  type: 'prometheus',
-                  uid: '$prometheus',
-                }}
-                query={{
-                  refId: 'workloads',
-                  query: variableQuery(
-                    queries.workloads.labelsByClusterNamespace,
-                  ),
-                }}
-                refresh={VariableRefresh.onTimeRangeChanged}
-                isMulti={true}
-                includeAll={true}
-                initialValue={'$__all'}
-                allValue=".+"
-                regex={`/workload="(?<value>[^"]+)/`}
-                sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+              <CustomVariable
+                name="namespace"
+                label="Namespace"
+                query={namespace}
+                initialValue={namespace}
+                hide={VariableHide.hideVariable}
               >
-                <CustomVariable
-                  name="pod"
-                  label="Pod"
-                  query=".+"
-                  initialValue=".+"
-                  hide={VariableHide.hideVariable}
+                <QueryVariable
+                  name="workload"
+                  label="Workload"
+                  datasource={{
+                    type: 'prometheus',
+                    uid: '$prometheus',
+                  }}
+                  query={{
+                    refId: 'workloads',
+                    query: variableQuery(
+                      queries.workloads.labelsByClusterNamespace,
+                    ),
+                  }}
+                  refresh={VariableRefresh.onTimeRangeChanged}
+                  isMulti={true}
+                  includeAll={true}
+                  initialValue={'$__all'}
+                  allValue=".+"
+                  regex={`/workload="(?<value>[^"]+)/`}
+                  sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                 >
-                  <QueryVariable
-                    name="pvc"
-                    label="PersistentVolumeClaim"
-                    datasource={{
-                      type: 'prometheus',
-                      uid: '$prometheus',
-                    }}
-                    query={{
-                      refId: 'pvcs',
-                      query: variableQuery(
-                        queries.persistentVolumeClaims
-                          .labelsByClusterNamespacePod,
-                      ),
-                    }}
-                    refresh={VariableRefresh.onTimeRangeChanged}
-                    isMulti={true}
-                    includeAll={true}
-                    initialValue={'$__all'}
-                    sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+                  <CustomVariable
+                    name="pod"
+                    label="Pod"
+                    query=".+"
+                    initialValue=".+"
+                    hide={VariableHide.hideVariable}
                   >
-                    <PluginPage
-                      pageNav={{
-                        text: namespace,
-                        parentItem: {
-                          text: 'Namespaces',
-                          url: prefixRoute(ROUTES.MetricsNamespaces),
-                        },
+                    <QueryVariable
+                      name="pvc"
+                      label="PersistentVolumeClaim"
+                      datasource={{
+                        type: 'prometheus',
+                        uid: '$prometheus',
                       }}
-                      renderTitle={() => (
-                        <Stack gap={0} alignItems="center" direction="row">
-                          <img
-                            className={styles.pluginPage.title.image}
-                            alt={namespace}
-                            src={resourcesImg}
-                          />
-                          <h1>{namespace}</h1>
-                          <Badge
-                            className={styles.pluginPage.title.badge}
-                            color="blue"
-                            text="namespace"
-                          />
-                        </Stack>
-                      )}
-                      subTitle={pluginJson.info.description}
-                      actions={
-                        <>
-                          <TimeRangePicker />
-                          <RefreshPicker />
-                        </>
-                      }
+                      query={{
+                        refId: 'pvcs',
+                        query: variableQuery(
+                          queries.persistentVolumeClaims
+                            .labelsByClusterNamespacePod,
+                        ),
+                      }}
+                      refresh={VariableRefresh.onTimeRangeChanged}
+                      isMulti={true}
+                      includeAll={true}
+                      initialValue={'$__all'}
+                      sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                     >
-                      <TabsBar className={styles.dashboard.tabsBar}>
-                        <Tab
-                          label="Overview"
-                          active={activeTab === 'overview'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('overview');
-                          }}
-                        />
-                        <Tab
-                          label="CPU"
-                          active={activeTab === 'cpu'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('cpu');
-                          }}
-                        />
-                        <Tab
-                          label="Memory"
-                          active={activeTab === 'memory'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('memory');
-                          }}
-                        />
-                        <Tab
-                          label="Network"
-                          active={activeTab === 'network'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('network');
-                          }}
-                        />
-                        <Tab
-                          label="Storage"
-                          active={activeTab === 'storage'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('storage');
-                          }}
-                        />
-                      </TabsBar>
-                      {activeTab === 'overview' && <NamespacePageOverview />}
-                      {activeTab === 'cpu' && <NamespacePageCPU />}
-                      {activeTab === 'memory' && <NamespacePageMemory />}
-                      {activeTab === 'network' && <NamespacePageNetwork />}
-                      {activeTab === 'storage' && <NamespacePageStorage />}
-                    </PluginPage>
-                  </QueryVariable>
-                </CustomVariable>
-              </QueryVariable>
-            </CustomVariable>
+                      <PluginPage
+                        pageNav={{
+                          text: namespace,
+                          parentItem: {
+                            text: 'Namespaces',
+                            url: prefixRoute(ROUTES.MetricsNamespaces),
+                          },
+                        }}
+                        renderTitle={() => (
+                          <Stack gap={0} alignItems="center" direction="row">
+                            <img
+                              className={styles.pluginPage.title.image}
+                              alt={namespace}
+                              src={resourcesImg}
+                            />
+                            <h1>{namespace}</h1>
+                            <Badge
+                              className={styles.pluginPage.title.badge}
+                              color="blue"
+                              text="namespace"
+                            />
+                          </Stack>
+                        )}
+                        subTitle={pluginJson.info.description}
+                        actions={
+                          <>
+                            <TimeRangePicker />
+                            <RefreshPicker />
+                          </>
+                        }
+                      >
+                        <TabsBar className={styles.dashboard.tabsBar}>
+                          <Tab
+                            label="Overview"
+                            active={activeTab === 'overview'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('overview');
+                            }}
+                          />
+                          <Tab
+                            label="CPU"
+                            active={activeTab === 'cpu'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('cpu');
+                            }}
+                          />
+                          <Tab
+                            label="Memory"
+                            active={activeTab === 'memory'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('memory');
+                            }}
+                          />
+                          <Tab
+                            label="Network"
+                            active={activeTab === 'network'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('network');
+                            }}
+                          />
+                          <Tab
+                            label="Storage"
+                            active={activeTab === 'storage'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('storage');
+                            }}
+                          />
+                          <TabLogs
+                            resource="namespace"
+                            active={activeTab === 'logs'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('logs');
+                            }}
+                          />
+                        </TabsBar>
+                        {activeTab === 'overview' && <NamespacePageOverview />}
+                        {activeTab === 'cpu' && <NamespacePageCPU />}
+                        {activeTab === 'memory' && <NamespacePageMemory />}
+                        {activeTab === 'network' && <NamespacePageNetwork />}
+                        {activeTab === 'storage' && <NamespacePageStorage />}
+                        {activeTab === 'logs' && (
+                          <TabLogsContent
+                            page="namespace"
+                            resource="namespace"
+                          />
+                        )}
+                      </PluginPage>
+                    </QueryVariable>
+                  </CustomVariable>
+                </QueryVariable>
+              </CustomVariable>
+            </QueryVariable>
           </QueryVariable>
         </QueryVariable>
       </DataSourceVariable>

--- a/src/components/metrics/nodes/NodePage.tsx
+++ b/src/components/metrics/nodes/NodePage.tsx
@@ -24,6 +24,8 @@ import { NodePageNetwork } from './NodePageNetwork';
 import { NodePageStorage } from './NodePageStorage';
 import { ROUTES } from '../../../constants';
 import { prefixRoute } from '../../../utils/utils.routing';
+import { TabLogsContent } from '../shared/TabLogsContent';
+import { TabLogs } from '../shared/TabLogs';
 
 export function NodePage() {
   const styles = useStyles2(getStyles);
@@ -72,119 +74,144 @@ export function NodePage() {
             refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
-            <CustomVariable
-              name="node"
-              label="Node"
-              query={node}
-              initialValue={node}
+            <QueryVariable
+              name="logs"
+              label="Logs"
+              datasource={{ type: datasourcePluginJson.id, uid: '$datasource' }}
+              query={{
+                refId: 'settings',
+                queryType: 'settings',
+                setting: 'integrationsMetricsLogs',
+                variableField: 'values',
+              }}
+              refresh={VariableRefresh.onDashboardLoad}
               hide={VariableHide.hideVariable}
             >
               <CustomVariable
-                name="namespace"
-                label="Namespace"
-                query=".+"
-                initialValue=".+"
+                name="node"
+                label="Node"
+                query={node}
+                initialValue={node}
                 hide={VariableHide.hideVariable}
               >
-                <QueryVariable
-                  name="pod"
-                  label="Pod"
-                  datasource={{
-                    type: 'prometheus',
-                    uid: '$prometheus',
-                  }}
-                  query={{
-                    refId: 'pods',
-                    query: variableQuery(queries.pods.labelsByClusterNode),
-                  }}
-                  refresh={VariableRefresh.onTimeRangeChanged}
-                  isMulti={true}
-                  includeAll={true}
-                  initialValue={'$__all'}
-                  sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+                <CustomVariable
+                  name="namespace"
+                  label="Namespace"
+                  query=".+"
+                  initialValue=".+"
+                  hide={VariableHide.hideVariable}
                 >
-                  <PluginPage
-                    pageNav={{
-                      text: node,
-                      parentItem: {
-                        text: 'Nodes',
-                        url: prefixRoute(ROUTES.MetricsNodes),
-                      },
+                  <QueryVariable
+                    name="pod"
+                    label="Pod"
+                    datasource={{
+                      type: 'prometheus',
+                      uid: '$prometheus',
                     }}
-                    renderTitle={() => (
-                      <Stack gap={0} alignItems="center" direction="row">
-                        <img
-                          className={styles.pluginPage.title.image}
-                          alt={node}
-                          src={resourcesImg}
-                        />
-                        <h1>{node}</h1>
-                        <Badge
-                          className={styles.pluginPage.title.badge}
-                          color="blue"
-                          text="node"
-                        />
-                      </Stack>
-                    )}
-                    subTitle={pluginJson.info.description}
-                    actions={
-                      <>
-                        <TimeRangePicker />
-                        <RefreshPicker />
-                      </>
-                    }
+                    query={{
+                      refId: 'pods',
+                      query: variableQuery(queries.pods.labelsByClusterNode),
+                    }}
+                    refresh={VariableRefresh.onTimeRangeChanged}
+                    isMulti={true}
+                    includeAll={true}
+                    initialValue={'$__all'}
+                    sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                   >
-                    <TabsBar className={styles.dashboard.tabsBar}>
-                      <Tab
-                        label="Overview"
-                        active={activeTab === 'overview'}
-                        onChangeTab={(ev) => {
-                          ev?.preventDefault();
-                          setActiveTab('overview');
-                        }}
-                      />
-                      <Tab
-                        label="CPU"
-                        active={activeTab === 'cpu'}
-                        onChangeTab={(ev) => {
-                          ev?.preventDefault();
-                          setActiveTab('cpu');
-                        }}
-                      />
-                      <Tab
-                        label="Memory"
-                        active={activeTab === 'memory'}
-                        onChangeTab={(ev) => {
-                          ev?.preventDefault();
-                          setActiveTab('memory');
-                        }}
-                      />
-                      <Tab
-                        label="Network"
-                        active={activeTab === 'network'}
-                        onChangeTab={(ev) => {
-                          ev?.preventDefault();
-                          setActiveTab('network');
-                        }}
-                      />
-                      <Tab
-                        label="Storage"
-                        active={activeTab === 'storage'}
-                        onChangeTab={(ev) => {
-                          ev?.preventDefault();
-                          setActiveTab('storage');
-                        }}
-                      />
-                    </TabsBar>
-                    {activeTab === 'overview' && <NodePageOverview />}
-                    {activeTab === 'cpu' && <NodePageCPU />}
-                    {activeTab === 'memory' && <NodePageMemory />}
-                    {activeTab === 'network' && <NodePageNetwork />}
-                    {activeTab === 'storage' && <NodePageStorage />}
-                  </PluginPage>
-                </QueryVariable>
+                    <PluginPage
+                      pageNav={{
+                        text: node,
+                        parentItem: {
+                          text: 'Nodes',
+                          url: prefixRoute(ROUTES.MetricsNodes),
+                        },
+                      }}
+                      renderTitle={() => (
+                        <Stack gap={0} alignItems="center" direction="row">
+                          <img
+                            className={styles.pluginPage.title.image}
+                            alt={node}
+                            src={resourcesImg}
+                          />
+                          <h1>{node}</h1>
+                          <Badge
+                            className={styles.pluginPage.title.badge}
+                            color="blue"
+                            text="node"
+                          />
+                        </Stack>
+                      )}
+                      subTitle={pluginJson.info.description}
+                      actions={
+                        <>
+                          <TimeRangePicker />
+                          <RefreshPicker />
+                        </>
+                      }
+                    >
+                      <TabsBar className={styles.dashboard.tabsBar}>
+                        <Tab
+                          label="Overview"
+                          active={activeTab === 'overview'}
+                          onChangeTab={(ev) => {
+                            ev?.preventDefault();
+                            setActiveTab('overview');
+                          }}
+                        />
+                        <Tab
+                          label="CPU"
+                          active={activeTab === 'cpu'}
+                          onChangeTab={(ev) => {
+                            ev?.preventDefault();
+                            setActiveTab('cpu');
+                          }}
+                        />
+                        <Tab
+                          label="Memory"
+                          active={activeTab === 'memory'}
+                          onChangeTab={(ev) => {
+                            ev?.preventDefault();
+                            setActiveTab('memory');
+                          }}
+                        />
+                        <Tab
+                          label="Network"
+                          active={activeTab === 'network'}
+                          onChangeTab={(ev) => {
+                            ev?.preventDefault();
+                            setActiveTab('network');
+                          }}
+                        />
+                        <Tab
+                          label="Storage"
+                          active={activeTab === 'storage'}
+                          onChangeTab={(ev) => {
+                            ev?.preventDefault();
+                            setActiveTab('storage');
+                          }}
+                        />
+                        <TabLogs
+                          resource="node"
+                          active={activeTab === 'logs'}
+                          onChangeTab={(ev) => {
+                            ev?.preventDefault();
+                            setActiveTab('logs');
+                          }}
+                        />
+                      </TabsBar>
+                      {activeTab === 'overview' && <NodePageOverview />}
+                      {activeTab === 'cpu' && <NodePageCPU />}
+                      {activeTab === 'memory' && <NodePageMemory />}
+                      {activeTab === 'network' && <NodePageNetwork />}
+                      {activeTab === 'storage' && <NodePageStorage />}
+                      {activeTab === 'logs' && (
+                        <TabLogsContent page="node" resource="node" />
+                      )}
+                    </PluginPage>
+                  </QueryVariable>
+                </CustomVariable>
               </CustomVariable>
-            </CustomVariable>
+            </QueryVariable>
           </QueryVariable>
         </QueryVariable>
       </DataSourceVariable>

--- a/src/components/metrics/pods/PodPage.tsx
+++ b/src/components/metrics/pods/PodPage.tsx
@@ -24,6 +24,8 @@ import { PodPageStorage } from './PodPageStorage';
 import { ROUTES } from '../../../constants';
 import { prefixRoute } from '../../../utils/utils.routing';
 import { queries, variableQuery } from '../queries';
+import { TabLogs } from '../shared/TabLogs';
+import { TabLogsContent } from '../shared/TabLogsContent';
 
 export function PodPage() {
   const styles = useStyles2(getStyles);
@@ -76,134 +78,159 @@ export function PodPage() {
             refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
-            <CustomVariable
-              name="node"
-              label="Node"
-              query=".+"
-              initialValue=".+"
+            <QueryVariable
+              name="logs"
+              label="Logs"
+              datasource={{ type: datasourcePluginJson.id, uid: '$datasource' }}
+              query={{
+                refId: 'settings',
+                queryType: 'settings',
+                setting: 'integrationsMetricsLogs',
+                variableField: 'values',
+              }}
+              refresh={VariableRefresh.onDashboardLoad}
               hide={VariableHide.hideVariable}
             >
               <CustomVariable
-                name="namespace"
-                label="Namespace"
-                query={namespace}
-                initialValue={namespace}
+                name="node"
+                label="Node"
+                query=".+"
+                initialValue=".+"
                 hide={VariableHide.hideVariable}
               >
                 <CustomVariable
-                  name="pod"
-                  label="Pod"
-                  query={pod}
-                  initialValue={pod}
+                  name="namespace"
+                  label="Namespace"
+                  query={namespace}
+                  initialValue={namespace}
                   hide={VariableHide.hideVariable}
                 >
-                  <QueryVariable
-                    name="pvc"
-                    label="PersistentVolumeClaim"
-                    datasource={{
-                      type: 'prometheus',
-                      uid: '$prometheus',
-                    }}
-                    query={{
-                      refId: 'pvcs',
-                      query: variableQuery(
-                        queries.persistentVolumeClaims
-                          .labelsByClusterNamespacePod,
-                      ),
-                    }}
-                    refresh={VariableRefresh.onTimeRangeChanged}
-                    isMulti={true}
-                    includeAll={true}
-                    initialValue={'$__all'}
-                    sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+                  <CustomVariable
+                    name="pod"
+                    label="Pod"
+                    query={pod}
+                    initialValue={pod}
+                    hide={VariableHide.hideVariable}
                   >
-                    <PluginPage
-                      pageNav={{
-                        text: pod,
-                        parentItem: {
-                          text: namespace,
-                          url: `${prefixRoute(ROUTES.MetricsNamespaces)}/${namespace}`,
-                          parentItem: {
-                            text: 'Pods',
-                            url: prefixRoute(ROUTES.MetricsPods),
-                          },
-                        },
+                    <QueryVariable
+                      name="pvc"
+                      label="PersistentVolumeClaim"
+                      datasource={{
+                        type: 'prometheus',
+                        uid: '$prometheus',
                       }}
-                      renderTitle={() => (
-                        <Stack gap={0} alignItems="center" direction="row">
-                          <img
-                            className={styles.pluginPage.title.image}
-                            alt={pod}
-                            src={resourcesImg}
-                          />
-                          <h1>{pod}</h1>
-                          <Badge
-                            className={styles.pluginPage.title.badge}
-                            color="blue"
-                            text="pod"
-                          />
-                        </Stack>
-                      )}
-                      subTitle={pluginJson.info.description}
-                      actions={
-                        <>
-                          <TimeRangePicker />
-                          <RefreshPicker />
-                        </>
-                      }
+                      query={{
+                        refId: 'pvcs',
+                        query: variableQuery(
+                          queries.persistentVolumeClaims
+                            .labelsByClusterNamespacePod,
+                        ),
+                      }}
+                      refresh={VariableRefresh.onTimeRangeChanged}
+                      isMulti={true}
+                      includeAll={true}
+                      initialValue={'$__all'}
+                      sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                     >
-                      <TabsBar className={styles.dashboard.tabsBar}>
-                        <Tab
-                          label="Overview"
-                          active={activeTab === 'overview'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('overview');
-                          }}
-                        />
-                        <Tab
-                          label="CPU"
-                          active={activeTab === 'cpu'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('cpu');
-                          }}
-                        />
-                        <Tab
-                          label="Memory"
-                          active={activeTab === 'memory'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('memory');
-                          }}
-                        />
-                        <Tab
-                          label="Network"
-                          active={activeTab === 'network'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('network');
-                          }}
-                        />
-                        <Tab
-                          label="Storage"
-                          active={activeTab === 'storage'}
-                          onChangeTab={(ev) => {
-                            ev?.preventDefault();
-                            setActiveTab('storage');
-                          }}
-                        />
-                      </TabsBar>
-                      {activeTab === 'overview' && <PodPageOverview />}
-                      {activeTab === 'cpu' && <PodPageCPU />}
-                      {activeTab === 'memory' && <PodPageMemory />}
-                      {activeTab === 'network' && <PodPageNetwork />}
-                      {activeTab === 'storage' && <PodPageStorage />}
-                    </PluginPage>
-                  </QueryVariable>
+                      <PluginPage
+                        pageNav={{
+                          text: pod,
+                          parentItem: {
+                            text: namespace,
+                            url: `${prefixRoute(ROUTES.MetricsNamespaces)}/${namespace}`,
+                            parentItem: {
+                              text: 'Pods',
+                              url: prefixRoute(ROUTES.MetricsPods),
+                            },
+                          },
+                        }}
+                        renderTitle={() => (
+                          <Stack gap={0} alignItems="center" direction="row">
+                            <img
+                              className={styles.pluginPage.title.image}
+                              alt={pod}
+                              src={resourcesImg}
+                            />
+                            <h1>{pod}</h1>
+                            <Badge
+                              className={styles.pluginPage.title.badge}
+                              color="blue"
+                              text="pod"
+                            />
+                          </Stack>
+                        )}
+                        subTitle={pluginJson.info.description}
+                        actions={
+                          <>
+                            <TimeRangePicker />
+                            <RefreshPicker />
+                          </>
+                        }
+                      >
+                        <TabsBar className={styles.dashboard.tabsBar}>
+                          <Tab
+                            label="Overview"
+                            active={activeTab === 'overview'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('overview');
+                            }}
+                          />
+                          <Tab
+                            label="CPU"
+                            active={activeTab === 'cpu'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('cpu');
+                            }}
+                          />
+                          <Tab
+                            label="Memory"
+                            active={activeTab === 'memory'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('memory');
+                            }}
+                          />
+                          <Tab
+                            label="Network"
+                            active={activeTab === 'network'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('network');
+                            }}
+                          />
+                          <Tab
+                            label="Storage"
+                            active={activeTab === 'storage'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('storage');
+                            }}
+                          />
+                          <TabLogs
+                            resource="pod"
+                            active={activeTab === 'logs'}
+                            onChangeTab={(ev) => {
+                              ev?.preventDefault();
+                              setActiveTab('logs');
+                            }}
+                          />
+                        </TabsBar>
+                        {activeTab === 'overview' && <PodPageOverview />}
+                        {activeTab === 'cpu' && <PodPageCPU />}
+                        {activeTab === 'memory' && <PodPageMemory />}
+                        {activeTab === 'network' && <PodPageNetwork />}
+                        {activeTab === 'storage' && <PodPageStorage />}
+                        {activeTab === 'logs' && (
+                          <TabLogsContent page="pod" resource="pod" />
+                        )}
+                      </PluginPage>
+                    </QueryVariable>
+                  </CustomVariable>
                 </CustomVariable>
               </CustomVariable>
-            </CustomVariable>
+            </QueryVariable>
           </QueryVariable>
         </QueryVariable>
       </DataSourceVariable>

--- a/src/components/metrics/queries.ts
+++ b/src/components/metrics/queries.ts
@@ -4151,6 +4151,14 @@ sum(
 ) by(namespace,pod)`,
   },
   containers: {
+    labelsByClusterNamespacePod: `label_values(
+  kube_pod_container_info{
+    cluster=~"$cluster",
+    namespace=~"$namespace",
+    pod=~"$pod"
+  },
+  container
+)`,
     info: `last_over_time(
   (
     max(

--- a/src/components/metrics/shared/TabLogs.tsx
+++ b/src/components/metrics/shared/TabLogs.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Tab } from '@grafana/ui';
+import { useVariables } from '@grafana/scenes-react';
+
+interface Props {
+  resource: string;
+  active: boolean;
+  onChangeTab: (ev: React.MouseEvent<HTMLElement>) => void;
+}
+
+export function TabLogs({ resource, active, onChangeTab }: Props) {
+  const variables = useVariables();
+  const settingsVariable = variables.find((v) => v.state.name === 'logs');
+  // @ts-expect-error
+  const settings = settingsVariable?.state.text;
+
+  if (
+    settings ||
+    resource === 'pod' ||
+    resource === 'daemonset' ||
+    resource === 'statefulset' ||
+    resource === 'deployment' ||
+    resource === 'job'
+  ) {
+    return <Tab label="Logs" active={active} onChangeTab={onChangeTab} />;
+  }
+
+  return <></>;
+}

--- a/src/components/metrics/shared/TabLogsContent.tsx
+++ b/src/components/metrics/shared/TabLogsContent.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import {
+  QueryVariable,
+  VariableControl,
+  VizPanel,
+  useQueryRunner,
+  useVariables,
+} from '@grafana/scenes-react';
+import { VizConfigBuilders } from '@grafana/scenes';
+
+import datasourcePluginJson from '../../../datasource/plugin.json';
+import { getStyles } from '../../../utils/utils.styles';
+import { useVizPanelMenu } from 'hooks/useVizPanelMenu';
+import { queries, variableQuery } from '../queries';
+import { VariableRefresh, VariableSort } from '@grafana/data';
+import { getResourceInfo } from './TableKubernetesResource';
+
+interface Props {
+  page: string;
+  resource: string;
+}
+
+export function TabLogsContent({ page, resource }: Props) {
+  const variables = useVariables();
+  const settingsVariable = variables.find((v) => v.state.name === 'logs');
+  // @ts-expect-error
+  const settings = settingsVariable?.state.text;
+
+  if (settings) {
+    return <LogsCustomDatasource page={page} settings={settings} />;
+  }
+
+  return <LogsKubernetesDatasource resource={resource} />;
+}
+
+function LogsCustomDatasource({
+  page,
+  settings,
+}: {
+  page: string;
+  settings: string;
+}) {
+  const styles = useStyles2(getStyles);
+  const parsedSettings = JSON.parse(settings);
+
+  if (!parsedSettings[page]) {
+    return <></>;
+  }
+
+  return (
+    <Stack direction="column" gap={2} height="calc(100% - 54px)">
+      <div className={styles.dashboard.row.height100percent}>
+        <LogsPanel query={parsedSettings[page]} />
+      </div>
+    </Stack>
+  );
+}
+
+function LogsKubernetesDatasource({ resource }: { resource: string }) {
+  const styles = useStyles2(getStyles);
+  const info = getResourceInfo(resource);
+
+  if (!info) {
+    return <></>;
+  }
+
+  return (
+    <QueryVariable
+      name="container"
+      label="Container"
+      datasource={{
+        type: 'prometheus',
+        uid: '$prometheus',
+      }}
+      query={{
+        refId: 'containers',
+        query: variableQuery(queries.containers.labelsByClusterNamespacePod),
+      }}
+      refresh={VariableRefresh.onTimeRangeChanged}
+      isMulti={false}
+      includeAll={false}
+      sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+    >
+      <Stack direction="column" gap={2} height="calc(100% - 54px)">
+        <div className={styles.dashboard.header.container}>
+          <VariableControl name="container" />
+          <div className={styles.dashboard.header.spacer} />
+        </div>
+        <div className={styles.dashboard.row.height100percent}>
+          <LogsPanel
+            query={{
+              datasource: {
+                type: datasourcePluginJson.id,
+                uid: '$datasource',
+              },
+              queries: [
+                {
+                  refId: 'A',
+                  queryType: 'kubernetes-logs',
+                  resourceId: info.resourceId,
+                  namespace: '$namespace',
+                  name: resource === 'pod' ? '$pod' : '$workload',
+                  container: '$container',
+                  filter: '',
+                  tail: 0,
+                  previous: false,
+                },
+              ],
+            }}
+          />
+        </div>
+      </Stack>
+    </QueryVariable>
+  );
+}
+
+function LogsPanel({ query }: { query: any }) {
+  const dataProvider = useQueryRunner(query);
+
+  const viz = VizConfigBuilders.logs()
+    .setOption('showTime', true)
+    .setOption('showControls', true)
+    .setOption('enableLogDetails', true)
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel title="Logs" menu={menu} viz={viz} dataProvider={dataProvider} />
+  );
+}

--- a/src/components/metrics/shared/TableKubernetesResource.tsx
+++ b/src/components/metrics/shared/TableKubernetesResource.tsx
@@ -7,7 +7,7 @@ import datasourcePluginJson from '../../../datasource/plugin.json';
 import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
 import { getStyles } from '../../../utils/utils.styles';
 
-function getResourceInfo(resource: string):
+export function getResourceInfo(resource: string):
   | {
     title: string;
     resourceId: string;

--- a/src/components/metrics/workloads/WorkloadPage.tsx
+++ b/src/components/metrics/workloads/WorkloadPage.tsx
@@ -24,6 +24,8 @@ import { WorkloadPageNetwork } from './WorkloadPageNetwork';
 import { WorkloadPageStorage } from './WorkloadPageStorage';
 import { ROUTES } from '../../../constants';
 import { prefixRoute } from '../../../utils/utils.routing';
+import { TabLogs } from '../shared/TabLogs';
+import { TabLogsContent } from '../shared/TabLogsContent';
 
 export function WorkloadPage() {
   const styles = useStyles2(getStyles);
@@ -84,65 +86,58 @@ export function WorkloadPage() {
             refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
-            <CustomVariable
-              name="node"
-              label="Node"
-              query=".+"
-              initialValue=".+"
+            <QueryVariable
+              name="logs"
+              label="Logs"
+              datasource={{ type: datasourcePluginJson.id, uid: '$datasource' }}
+              query={{
+                refId: 'settings',
+                queryType: 'settings',
+                setting: 'integrationsMetricsLogs',
+                variableField: 'values',
+              }}
+              refresh={VariableRefresh.onDashboardLoad}
               hide={VariableHide.hideVariable}
             >
               <CustomVariable
-                name="namespace"
-                label="Namespace"
-                query={namespace}
-                initialValue={namespace}
+                name="node"
+                label="Node"
+                query=".+"
+                initialValue=".+"
                 hide={VariableHide.hideVariable}
               >
                 <CustomVariable
-                  name="workloadtype"
-                  label="Workload Type"
-                  query={workloadType}
-                  initialValue={workloadType}
+                  name="namespace"
+                  label="Namespace"
+                  query={namespace}
+                  initialValue={namespace}
                   hide={VariableHide.hideVariable}
                 >
                   <CustomVariable
-                    name="workload"
-                    label="Workload"
-                    query={workload.toLowerCase()}
-                    initialValue={workload.toLowerCase()}
+                    name="workloadtype"
+                    label="Workload Type"
+                    query={workloadType}
+                    initialValue={workloadType}
                     hide={VariableHide.hideVariable}
                   >
-                    <QueryVariable
-                      name="pod"
-                      label="Pod"
-                      datasource={{
-                        type: 'prometheus',
-                        uid: '$prometheus',
-                      }}
-                      query={{
-                        refId: 'pods',
-                        query: variableQuery(
-                          queries.pods.labelsByClusterNamespaceWorkload,
-                        ),
-                      }}
-                      refresh={VariableRefresh.onTimeRangeChanged}
-                      isMulti={true}
-                      includeAll={true}
-                      initialValue={'$__all'}
-                      sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+                    <CustomVariable
+                      name="workload"
+                      label="Workload"
+                      query={workload.toLowerCase()}
+                      initialValue={workload.toLowerCase()}
+                      hide={VariableHide.hideVariable}
                     >
                       <QueryVariable
-                        name="pvc"
-                        label="PersistentVolumeClaim"
+                        name="pod"
+                        label="Pod"
                         datasource={{
                           type: 'prometheus',
                           uid: '$prometheus',
                         }}
                         query={{
-                          refId: 'pvcs',
+                          refId: 'pods',
                           query: variableQuery(
-                            queries.persistentVolumeClaims
-                              .labelsByClusterNamespacePod,
+                            queries.pods.labelsByClusterNamespaceWorkload,
                           ),
                         }}
                         refresh={VariableRefresh.onTimeRangeChanged}
@@ -151,99 +146,138 @@ export function WorkloadPage() {
                         initialValue={'$__all'}
                         sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                       >
-                        <PluginPage
-                          pageNav={{
-                            text: workload,
-                            parentItem: {
-                              text: namespace,
-                              url: `${prefixRoute(ROUTES.MetricsNamespaces)}/${namespace}`,
-                              parentItem: {
-                                text: 'Workloads',
-                                url: prefixRoute(ROUTES.MetricsWorkloads),
-                              },
-                            },
+                        <QueryVariable
+                          name="pvc"
+                          label="PersistentVolumeClaim"
+                          datasource={{
+                            type: 'prometheus',
+                            uid: '$prometheus',
                           }}
-                          renderTitle={() => (
-                            <Stack gap={0} alignItems="center" direction="row">
-                              <img
-                                className={styles.pluginPage.title.image}
-                                alt={workload}
-                                src={resourcesImg}
-                              />
-                              <h1>{workload}</h1>
-                              <Badge
-                                className={styles.pluginPage.title.badge}
-                                color="blue"
-                                text={workloadType.toLowerCase()}
-                              />
-                            </Stack>
-                          )}
-                          subTitle={pluginJson.info.description}
-                          actions={
-                            <>
-                              <TimeRangePicker />
-                              <RefreshPicker />
-                            </>
-                          }
+                          query={{
+                            refId: 'pvcs',
+                            query: variableQuery(
+                              queries.persistentVolumeClaims
+                                .labelsByClusterNamespacePod,
+                            ),
+                          }}
+                          refresh={VariableRefresh.onTimeRangeChanged}
+                          isMulti={true}
+                          includeAll={true}
+                          initialValue={'$__all'}
+                          sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                         >
-                          <TabsBar className={styles.dashboard.tabsBar}>
-                            <Tab
-                              label="Overview"
-                              active={activeTab === 'overview'}
-                              onChangeTab={(ev) => {
-                                ev?.preventDefault();
-                                setActiveTab('overview');
-                              }}
-                            />
-                            <Tab
-                              label="CPU"
-                              active={activeTab === 'cpu'}
-                              onChangeTab={(ev) => {
-                                ev?.preventDefault();
-                                setActiveTab('cpu');
-                              }}
-                            />
-                            <Tab
-                              label="Memory"
-                              active={activeTab === 'memory'}
-                              onChangeTab={(ev) => {
-                                ev?.preventDefault();
-                                setActiveTab('memory');
-                              }}
-                            />
-                            <Tab
-                              label="Network"
-                              active={activeTab === 'network'}
-                              onChangeTab={(ev) => {
-                                ev?.preventDefault();
-                                setActiveTab('network');
-                              }}
-                            />
-                            <Tab
-                              label="Storage"
-                              active={activeTab === 'storage'}
-                              onChangeTab={(ev) => {
-                                ev?.preventDefault();
-                                setActiveTab('storage');
-                              }}
-                            />
-                          </TabsBar>
-                          {activeTab === 'overview' && (
-                            <WorkloadPageOverview
-                              workloadType={workloadType.toLowerCase()}
-                            />
-                          )}
-                          {activeTab === 'cpu' && <WorkloadPageCPU />}
-                          {activeTab === 'memory' && <WorkloadPageMemory />}
-                          {activeTab === 'network' && <WorkloadPageNetwork />}
-                          {activeTab === 'storage' && <WorkloadPageStorage />}
-                        </PluginPage>
+                          <PluginPage
+                            pageNav={{
+                              text: workload,
+                              parentItem: {
+                                text: namespace,
+                                url: `${prefixRoute(ROUTES.MetricsNamespaces)}/${namespace}`,
+                                parentItem: {
+                                  text: 'Workloads',
+                                  url: prefixRoute(ROUTES.MetricsWorkloads),
+                                },
+                              },
+                            }}
+                            renderTitle={() => (
+                              <Stack
+                                gap={0}
+                                alignItems="center"
+                                direction="row"
+                              >
+                                <img
+                                  className={styles.pluginPage.title.image}
+                                  alt={workload}
+                                  src={resourcesImg}
+                                />
+                                <h1>{workload}</h1>
+                                <Badge
+                                  className={styles.pluginPage.title.badge}
+                                  color="blue"
+                                  text={workloadType.toLowerCase()}
+                                />
+                              </Stack>
+                            )}
+                            subTitle={pluginJson.info.description}
+                            actions={
+                              <>
+                                <TimeRangePicker />
+                                <RefreshPicker />
+                              </>
+                            }
+                          >
+                            <TabsBar className={styles.dashboard.tabsBar}>
+                              <Tab
+                                label="Overview"
+                                active={activeTab === 'overview'}
+                                onChangeTab={(ev) => {
+                                  ev?.preventDefault();
+                                  setActiveTab('overview');
+                                }}
+                              />
+                              <Tab
+                                label="CPU"
+                                active={activeTab === 'cpu'}
+                                onChangeTab={(ev) => {
+                                  ev?.preventDefault();
+                                  setActiveTab('cpu');
+                                }}
+                              />
+                              <Tab
+                                label="Memory"
+                                active={activeTab === 'memory'}
+                                onChangeTab={(ev) => {
+                                  ev?.preventDefault();
+                                  setActiveTab('memory');
+                                }}
+                              />
+                              <Tab
+                                label="Network"
+                                active={activeTab === 'network'}
+                                onChangeTab={(ev) => {
+                                  ev?.preventDefault();
+                                  setActiveTab('network');
+                                }}
+                              />
+                              <Tab
+                                label="Storage"
+                                active={activeTab === 'storage'}
+                                onChangeTab={(ev) => {
+                                  ev?.preventDefault();
+                                  setActiveTab('storage');
+                                }}
+                              />
+                              <TabLogs
+                                resource={workloadType}
+                                active={activeTab === 'logs'}
+                                onChangeTab={(ev) => {
+                                  ev?.preventDefault();
+                                  setActiveTab('logs');
+                                }}
+                              />
+                            </TabsBar>
+                            {activeTab === 'overview' && (
+                              <WorkloadPageOverview
+                                workloadType={workloadType.toLowerCase()}
+                              />
+                            )}
+                            {activeTab === 'cpu' && <WorkloadPageCPU />}
+                            {activeTab === 'memory' && <WorkloadPageMemory />}
+                            {activeTab === 'network' && <WorkloadPageNetwork />}
+                            {activeTab === 'storage' && <WorkloadPageStorage />}
+                            {activeTab === 'logs' && (
+                              <TabLogsContent
+                                page="workload"
+                                resource={workloadType}
+                              />
+                            )}
+                          </PluginPage>
+                        </QueryVariable>
                       </QueryVariable>
-                    </QueryVariable>
+                    </CustomVariable>
                   </CustomVariable>
                 </CustomVariable>
               </CustomVariable>
-            </CustomVariable>
+            </QueryVariable>
           </QueryVariable>
         </QueryVariable>
       </DataSourceVariable>

--- a/src/datasource/components/configeditor/Integrations.tsx
+++ b/src/datasource/components/configeditor/Integrations.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react';
-import { InlineField, Input, useStyles2 } from '@grafana/ui';
+import { InlineField, Input, TextArea, useStyles2 } from '@grafana/ui';
 import {
   DataSourcePluginOptionsEditorProps,
   GrafanaTheme2,
@@ -57,6 +57,22 @@ export function Integrations({ options, onOptionsChange }: Props) {
           }}
           value={options.jsonData.integrationsMetricsClusterLabel}
           width={65}
+        />
+      </InlineField>
+      <InlineField label="Metrics logs queries" labelWidth={30} interactive>
+        <TextArea
+          rows={3}
+          cols={56}
+          onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
+            onOptionsChange({
+              ...options,
+              jsonData: {
+                ...options.jsonData,
+                integrationsMetricsLogs: event.target.value,
+              },
+            });
+          }}
+          value={options.jsonData.integrationsMetricsLogs}
         />
       </InlineField>
       <InlineField label="Traces query" labelWidth={30} interactive>

--- a/src/datasource/types/settings.ts
+++ b/src/datasource/types/settings.ts
@@ -26,6 +26,7 @@ export interface DataSourceOptions extends DataSourceJsonData {
   generateKubeconfigRedirectUrls?: string[];
   integrationsMetricsDatasourceUid?: string;
   integrationsMetricsClusterLabel?: string;
+  integrationsMetricsLogs?: string;
   integrationsTracesQuery?: string;
 }
 


### PR DESCRIPTION
Next to the overview, cpu, memory, network and storage tabs, there is
now a logs tab that shows the logs of the selected resource. By default
the logs tab uses the Kubernetes datasource to show the logs, but it can
also be configured to use any other datasource that supports logs, such
as VictoriaLogs.
