### PR TITLE
Use Actions from Integrations in Resources Table

### DIFF
--- a/src/datasource/components/certmanager/Actions.tsx
+++ b/src/datasource/components/certmanager/Actions.tsx
@@ -7,6 +7,8 @@ import { Renew } from './Renew';
 import { Details } from './Details';
 import { CRApprove } from './CRApprove';
 import { CRDeny } from './CRDeny';
+import { Delete } from '../kubernetes/Delete';
+import { Edit } from '../kubernetes/Edit';
 
 interface Props {
   query: Query;
@@ -39,6 +41,8 @@ export function Actions({ query, frame, rowIndex }: Props) {
             {resourceId === 'certificaterequest.cert-manager.io' && (
               <Menu.Item label="Deny" onClick={() => setOpen('crdeny')} />
             )}
+            <Menu.Item label="Edit" onClick={() => setOpen('edit')} />
+            <Menu.Item label="Delete" onClick={() => setOpen('delete')} />
           </Menu.Group>
         )}
       >
@@ -79,6 +83,25 @@ export function Actions({ query, frame, rowIndex }: Props) {
         resourceId={resourceId}
         name={name}
         isOpen={open === 'crdeny'}
+        onClose={() => setOpen('')}
+      />
+
+      {open === 'edit' && (
+        <Edit
+          datasource={datasource}
+          resourceId={resourceId}
+          namespace={namespace}
+          name={name}
+          onClose={() => setOpen('')}
+        />
+      )}
+
+      <Delete
+        datasource={datasource}
+        resourceId={resourceId}
+        namespace={namespace}
+        name={name}
+        isOpen={open === 'delete'}
         onClose={() => setOpen('')}
       />
     </>

--- a/src/datasource/components/flux/Actions.tsx
+++ b/src/datasource/components/flux/Actions.tsx
@@ -7,6 +7,8 @@ import { Reconcile } from './Reconcile';
 import { Details } from './Details';
 import { Suspend } from './Suspend';
 import { Resume } from './Resume';
+import { Delete } from '../kubernetes/Delete';
+import { Edit } from '../kubernetes/Edit';
 
 interface Props {
   query: Query;
@@ -82,6 +84,8 @@ export function Actions({ query, frame, rowIndex }: Props) {
               ].includes(resourceId) && (
                 <Menu.Item label="Resume" onClick={() => setOpen('resume')} />
               )}
+            <Menu.Item label="Edit" onClick={() => setOpen('edit')} />
+            <Menu.Item label="Delete" onClick={() => setOpen('delete')} />
           </Menu.Group>
         )}
       >
@@ -124,6 +128,25 @@ export function Actions({ query, frame, rowIndex }: Props) {
         namespace={namespace}
         name={name}
         isOpen={open === 'resume'}
+        onClose={() => setOpen('')}
+      />
+
+      {open === 'edit' && (
+        <Edit
+          datasource={datasource}
+          resourceId={resourceId}
+          namespace={namespace}
+          name={name}
+          onClose={() => setOpen('')}
+        />
+      )}
+
+      <Delete
+        datasource={datasource}
+        resourceId={resourceId}
+        namespace={namespace}
+        name={name}
+        isOpen={open === 'delete'}
         onClose={() => setOpen('')}
       />
     </>

--- a/src/datasource/transformations/kubernetes.tsx
+++ b/src/datasource/transformations/kubernetes.tsx
@@ -4,6 +4,8 @@ import { DataFrame, FieldType } from '@grafana/data';
 
 import { Query } from '../types/query';
 import { Actions } from '../components/kubernetes/Actions';
+import { Actions as FluxActions } from '../components/flux/Actions';
+import { Actions as CertManagerActions } from '../components/certmanager/Actions';
 
 export const kubernetesResourcesTransformation = (
   query: Query,
@@ -23,6 +25,48 @@ export const kubernetesResourcesTransformation = (
             cellOptions: {
               type: TableCellDisplayMode.Custom,
               cellComponent: (props: CustomCellRendererProps) => {
+                if (
+                  [
+                    'bucket.source.toolkit.fluxcd.io',
+                    'gitrepository.source.toolkit.fluxcd.io',
+                    'helmchart.source.toolkit.fluxcd.io',
+                    'helmrepository.source.toolkit.fluxcd.io',
+                    'ocirepository.source.toolkit.fluxcd.io',
+                    'kustomization.kustomize.toolkit.fluxcd.io',
+                    'helmrelease.helm.toolkit.fluxcd.io',
+                    'imagerepository.image.toolkit.fluxcd.io',
+                    'imageupdateautomation.image.toolkit.fluxcd.io',
+                    'receiver.notification.toolkit.fluxcd.io',
+                  ].includes(query.resourceId || '')
+                ) {
+                  return (
+                    <FluxActions
+                      query={query}
+                      frame={props.frame}
+                      rowIndex={props.rowIndex}
+                    />
+                  );
+                }
+
+                if (
+                  [
+                    'issuer.cert-manager.io',
+                    'order.acme.cert-manager.io',
+                    'challenge.acme.cert-manager.io',
+                    'clusterissuer.cert-manager.io',
+                    'certificaterequest.cert-manager.io',
+                    'certificate.cert-manager.io',
+                  ].includes(query.resourceId || '')
+                ) {
+                  return (
+                    <CertManagerActions
+                      query={query}
+                      frame={props.frame}
+                      rowIndex={props.rowIndex}
+                    />
+                  );
+                }
+
                 return (
                   <Actions
                     query={query}


### PR DESCRIPTION
Instead of the default Kubernetes actions, we now use the actions
defined by an integration, if the displayed resource is associated with
one. This means that we now show the Flux and cert-manager actions in
the resources table instead of the default Kubernetes actions.
