### PR TITLE
Add Restarts Annotation to Workload and Pod Pages

### DIFF
--- a/src/components/metrics/pods/PodPage.tsx
+++ b/src/components/metrics/pods/PodPage.tsx
@@ -10,6 +10,7 @@ import {
   TimeRangePicker,
   RefreshPicker,
   CustomVariable,
+  AnnotationLayer,
 } from '@grafana/scenes-react';
 
 import pluginJson from '../../../plugin.json';
@@ -132,100 +133,122 @@ export function PodPage() {
                       initialValue={'$__all'}
                       sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                     >
-                      <PluginPage
-                        pageNav={{
-                          text: pod,
-                          parentItem: {
-                            text: namespace,
-                            url: `${prefixRoute(ROUTES.MetricsNamespaces)}/${namespace}`,
-                            parentItem: {
-                              text: 'Pods',
-                              url: prefixRoute(ROUTES.MetricsPods),
-                            },
+                      <AnnotationLayer
+                        name="Restarts"
+                        query={{
+                          datasource: {
+                            type: 'prometheus',
+                            uid: '$prometheus',
+                          },
+                          enable: true,
+                          iconColor: 'orange',
+                          name: 'Restarts',
+                          textFormat: '{{pod}} restarted',
+                          target: {
+                            // @ts-ignore
+                            expr: queries.pods.restarts,
+                            limit: 100,
+                            matchAny: false,
+                            refId: 'Anno',
+                            type: 'dashboard',
                           },
                         }}
-                        renderTitle={() => (
-                          <Stack gap={0} alignItems="center" direction="row">
-                            <img
-                              className={styles.pluginPage.title.image}
-                              alt={pod}
-                              src={resourcesImg}
-                            />
-                            <h1>{pod}</h1>
-                            <Badge
-                              className={styles.pluginPage.title.badge}
-                              color="blue"
-                              text="pod"
-                            />
-                          </Stack>
-                        )}
-                        subTitle={pluginJson.info.description}
-                        actions={
-                          <>
-                            <TimeRangePicker />
-                            <RefreshPicker />
-                          </>
-                        }
                       >
-                        <TabsBar className={styles.dashboard.tabsBar}>
-                          <Tab
-                            label="Overview"
-                            active={activeTab === 'overview'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('overview');
-                            }}
-                          />
-                          <Tab
-                            label="CPU"
-                            active={activeTab === 'cpu'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('cpu');
-                            }}
-                          />
-                          <Tab
-                            label="Memory"
-                            active={activeTab === 'memory'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('memory');
-                            }}
-                          />
-                          <Tab
-                            label="Network"
-                            active={activeTab === 'network'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('network');
-                            }}
-                          />
-                          <Tab
-                            label="Storage"
-                            active={activeTab === 'storage'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('storage');
-                            }}
-                          />
-                          <TabLogs
-                            resource="pod"
-                            active={activeTab === 'logs'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('logs');
-                            }}
-                          />
-                        </TabsBar>
-                        {activeTab === 'overview' && <PodPageOverview />}
-                        {activeTab === 'cpu' && <PodPageCPU />}
-                        {activeTab === 'memory' && <PodPageMemory />}
-                        {activeTab === 'network' && <PodPageNetwork />}
-                        {activeTab === 'storage' && <PodPageStorage />}
-                        {activeTab === 'logs' && (
-                          <TabLogsContent page="pod" resource="pod" />
-                        )}
-                      </PluginPage>
+                        <PluginPage
+                          pageNav={{
+                            text: pod,
+                            parentItem: {
+                              text: namespace,
+                              url: `${prefixRoute(ROUTES.MetricsNamespaces)}/${namespace}`,
+                              parentItem: {
+                                text: 'Pods',
+                                url: prefixRoute(ROUTES.MetricsPods),
+                              },
+                            },
+                          }}
+                          renderTitle={() => (
+                            <Stack gap={0} alignItems="center" direction="row">
+                              <img
+                                className={styles.pluginPage.title.image}
+                                alt={pod}
+                                src={resourcesImg}
+                              />
+                              <h1>{pod}</h1>
+                              <Badge
+                                className={styles.pluginPage.title.badge}
+                                color="blue"
+                                text="pod"
+                              />
+                            </Stack>
+                          )}
+                          subTitle={pluginJson.info.description}
+                          actions={
+                            <>
+                              <TimeRangePicker />
+                              <RefreshPicker />
+                            </>
+                          }
+                        >
+                          <TabsBar className={styles.dashboard.tabsBar}>
+                            <Tab
+                              label="Overview"
+                              active={activeTab === 'overview'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('overview');
+                              }}
+                            />
+                            <Tab
+                              label="CPU"
+                              active={activeTab === 'cpu'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('cpu');
+                              }}
+                            />
+                            <Tab
+                              label="Memory"
+                              active={activeTab === 'memory'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('memory');
+                              }}
+                            />
+                            <Tab
+                              label="Network"
+                              active={activeTab === 'network'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('network');
+                              }}
+                            />
+                            <Tab
+                              label="Storage"
+                              active={activeTab === 'storage'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('storage');
+                              }}
+                            />
+                            <TabLogs
+                              resource="pod"
+                              active={activeTab === 'logs'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('logs');
+                              }}
+                            />
+                          </TabsBar>
+                          {activeTab === 'overview' && <PodPageOverview />}
+                          {activeTab === 'cpu' && <PodPageCPU />}
+                          {activeTab === 'memory' && <PodPageMemory />}
+                          {activeTab === 'network' && <PodPageNetwork />}
+                          {activeTab === 'storage' && <PodPageStorage />}
+                          {activeTab === 'logs' && (
+                            <TabLogsContent page="pod" resource="pod" />
+                          )}
+                        </PluginPage>
+                      </AnnotationLayer>
                     </QueryVariable>
                   </CustomVariable>
                 </CustomVariable>

--- a/src/components/metrics/pods/PodPageCPU.tsx
+++ b/src/components/metrics/pods/PodPageCPU.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Stack, useStyles2 } from '@grafana/ui';
-import { VariableControl } from '@grafana/scenes-react';
+import { DataLayerControl, VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -19,6 +19,7 @@ export function PodPageCPU() {
         <VariableControl name="prometheus" />
         <VariableControl name="cluster" />
         <VariableControl name="namespace" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 

--- a/src/components/metrics/pods/PodPageMemory.tsx
+++ b/src/components/metrics/pods/PodPageMemory.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Stack, useStyles2 } from '@grafana/ui';
-import { VariableControl } from '@grafana/scenes-react';
+import { DataLayerControl, VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -19,6 +19,7 @@ export function PodPageMemory() {
         <VariableControl name="prometheus" />
         <VariableControl name="cluster" />
         <VariableControl name="namespace" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 

--- a/src/components/metrics/pods/PodPageNetwork.tsx
+++ b/src/components/metrics/pods/PodPageNetwork.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Stack, useStyles2 } from '@grafana/ui';
-import { VariableControl } from '@grafana/scenes-react';
+import { DataLayerControl, VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -16,6 +16,7 @@ export function PodPageNetwork() {
         <VariableControl name="prometheus" />
         <VariableControl name="cluster" />
         <VariableControl name="namespace" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 

--- a/src/components/metrics/pods/PodPageOverview.tsx
+++ b/src/components/metrics/pods/PodPageOverview.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { RadioButtonGroup, Stack, useStyles2 } from '@grafana/ui';
-import { VariableControl } from '@grafana/scenes-react';
+import { DataLayerControl, VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -19,6 +19,7 @@ export function PodPageOverview() {
         <VariableControl name="prometheus" />
         <VariableControl name="cluster" />
         <VariableControl name="namespace" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 

--- a/src/components/metrics/pods/PodPageStorage.tsx
+++ b/src/components/metrics/pods/PodPageStorage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Stack, useStyles2 } from '@grafana/ui';
-import { VariableControl } from '@grafana/scenes-react';
+import { DataLayerControl, VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -18,6 +18,7 @@ export function PodPageStorage() {
         <VariableControl name="prometheus" />
         <VariableControl name="cluster" />
         <VariableControl name="namespace" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 

--- a/src/components/metrics/queries.ts
+++ b/src/components/metrics/queries.ts
@@ -4149,6 +4149,13 @@ sum(
     }[$__rate_interval]
   )
 ) by(namespace,pod)`,
+    restarts: `sum(
+  changes(
+    kube_pod_container_status_restarts_total{
+      cluster=~"$cluster",namespace="$namespace",pod=~"$pod"
+    }[$__interval]
+  )
+) by(pod)`,
   },
   containers: {
     labelsByClusterNamespacePod: `label_values(

--- a/src/components/metrics/workloads/WorkloadPage.tsx
+++ b/src/components/metrics/workloads/WorkloadPage.tsx
@@ -10,6 +10,7 @@ import {
   TimeRangePicker,
   RefreshPicker,
   CustomVariable,
+  AnnotationLayer,
 } from '@grafana/scenes-react';
 
 import pluginJson from '../../../plugin.json';
@@ -166,111 +167,137 @@ export function WorkloadPage() {
                           initialValue={'$__all'}
                           sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                         >
-                          <PluginPage
-                            pageNav={{
-                              text: workload,
-                              parentItem: {
-                                text: namespace,
-                                url: `${prefixRoute(ROUTES.MetricsNamespaces)}/${namespace}`,
-                                parentItem: {
-                                  text: 'Workloads',
-                                  url: prefixRoute(ROUTES.MetricsWorkloads),
-                                },
+                          <AnnotationLayer
+                            name="Restarts"
+                            query={{
+                              datasource: {
+                                type: 'prometheus',
+                                uid: '$prometheus',
+                              },
+                              enable: true,
+                              iconColor: 'orange',
+                              name: 'Restarts',
+                              textFormat: '{{pod}} restarted',
+                              target: {
+                                // @ts-ignore
+                                expr: queries.pods.restarts,
+                                limit: 100,
+                                matchAny: false,
+                                refId: 'Anno',
+                                type: 'dashboard',
                               },
                             }}
-                            renderTitle={() => (
-                              <Stack
-                                gap={0}
-                                alignItems="center"
-                                direction="row"
-                              >
-                                <img
-                                  className={styles.pluginPage.title.image}
-                                  alt={workload}
-                                  src={resourcesImg}
-                                />
-                                <h1>{workload}</h1>
-                                <Badge
-                                  className={styles.pluginPage.title.badge}
-                                  color="blue"
-                                  text={workloadType.toLowerCase()}
-                                />
-                              </Stack>
-                            )}
-                            subTitle={pluginJson.info.description}
-                            actions={
-                              <>
-                                <TimeRangePicker />
-                                <RefreshPicker />
-                              </>
-                            }
                           >
-                            <TabsBar className={styles.dashboard.tabsBar}>
-                              <Tab
-                                label="Overview"
-                                active={activeTab === 'overview'}
-                                onChangeTab={(ev) => {
-                                  ev?.preventDefault();
-                                  setActiveTab('overview');
-                                }}
-                              />
-                              <Tab
-                                label="CPU"
-                                active={activeTab === 'cpu'}
-                                onChangeTab={(ev) => {
-                                  ev?.preventDefault();
-                                  setActiveTab('cpu');
-                                }}
-                              />
-                              <Tab
-                                label="Memory"
-                                active={activeTab === 'memory'}
-                                onChangeTab={(ev) => {
-                                  ev?.preventDefault();
-                                  setActiveTab('memory');
-                                }}
-                              />
-                              <Tab
-                                label="Network"
-                                active={activeTab === 'network'}
-                                onChangeTab={(ev) => {
-                                  ev?.preventDefault();
-                                  setActiveTab('network');
-                                }}
-                              />
-                              <Tab
-                                label="Storage"
-                                active={activeTab === 'storage'}
-                                onChangeTab={(ev) => {
-                                  ev?.preventDefault();
-                                  setActiveTab('storage');
-                                }}
-                              />
-                              <TabLogs
-                                resource={workloadType}
-                                active={activeTab === 'logs'}
-                                onChangeTab={(ev) => {
-                                  ev?.preventDefault();
-                                  setActiveTab('logs');
-                                }}
-                              />
-                            </TabsBar>
-                            {activeTab === 'overview' && (
-                              <WorkloadPageOverview
-                                workloadType={workloadType.toLowerCase()}
-                              />
-                            )}
-                            {activeTab === 'cpu' && <WorkloadPageCPU />}
-                            {activeTab === 'memory' && <WorkloadPageMemory />}
-                            {activeTab === 'network' && <WorkloadPageNetwork />}
-                            {activeTab === 'storage' && <WorkloadPageStorage />}
-                            {activeTab === 'logs' && (
-                              <TabLogsContent
-                                page="workload"
-                                resource={workloadType}
-                              />
-                            )}
-                          </PluginPage>
+                            <PluginPage
+                              pageNav={{
+                                text: workload,
+                                parentItem: {
+                                  text: namespace,
+                                  url: `${prefixRoute(ROUTES.MetricsNamespaces)}/${namespace}`,
+                                  parentItem: {
+                                    text: 'Workloads',
+                                    url: prefixRoute(ROUTES.MetricsWorkloads),
+                                  },
+                                },
+                              }}
+                              renderTitle={() => (
+                                <Stack
+                                  gap={0}
+                                  alignItems="center"
+                                  direction="row"
+                                >
+                                  <img
+                                    className={styles.pluginPage.title.image}
+                                    alt={workload}
+                                    src={resourcesImg}
+                                  />
+                                  <h1>{workload}</h1>
+                                  <Badge
+                                    className={styles.pluginPage.title.badge}
+                                    color="blue"
+                                    text={workloadType.toLowerCase()}
+                                  />
+                                </Stack>
+                              )}
+                              subTitle={pluginJson.info.description}
+                              actions={
+                                <>
+                                  <TimeRangePicker />
+                                  <RefreshPicker />
+                                </>
+                              }
+                            >
+                              <TabsBar className={styles.dashboard.tabsBar}>
+                                <Tab
+                                  label="Overview"
+                                  active={activeTab === 'overview'}
+                                  onChangeTab={(ev) => {
+                                    ev?.preventDefault();
+                                    setActiveTab('overview');
+                                  }}
+                                />
+                                <Tab
+                                  label="CPU"
+                                  active={activeTab === 'cpu'}
+                                  onChangeTab={(ev) => {
+                                    ev?.preventDefault();
+                                    setActiveTab('cpu');
+                                  }}
+                                />
+                                <Tab
+                                  label="Memory"
+                                  active={activeTab === 'memory'}
+                                  onChangeTab={(ev) => {
+                                    ev?.preventDefault();
+                                    setActiveTab('memory');
+                                  }}
+                                />
+                                <Tab
+                                  label="Network"
+                                  active={activeTab === 'network'}
+                                  onChangeTab={(ev) => {
+                                    ev?.preventDefault();
+                                    setActiveTab('network');
+                                  }}
+                                />
+                                <Tab
+                                  label="Storage"
+                                  active={activeTab === 'storage'}
+                                  onChangeTab={(ev) => {
+                                    ev?.preventDefault();
+                                    setActiveTab('storage');
+                                  }}
+                                />
+                                <TabLogs
+                                  resource={workloadType}
+                                  active={activeTab === 'logs'}
+                                  onChangeTab={(ev) => {
+                                    ev?.preventDefault();
+                                    setActiveTab('logs');
+                                  }}
+                                />
+                              </TabsBar>
+                              {activeTab === 'overview' && (
+                                <WorkloadPageOverview
+                                  workloadType={workloadType.toLowerCase()}
+                                />
+                              )}
+                              {activeTab === 'cpu' && <WorkloadPageCPU />}
+                              {activeTab === 'memory' && <WorkloadPageMemory />}
+                              {activeTab === 'network' && (
+                                <WorkloadPageNetwork />
+                              )}
+                              {activeTab === 'storage' && (
+                                <WorkloadPageStorage />
+                              )}
+                              {activeTab === 'logs' && (
+                                <TabLogsContent
+                                  page="workload"
+                                  resource={workloadType}
+                                />
+                              )}
+                            </PluginPage>
+                          </AnnotationLayer>
                         </QueryVariable>
                       </QueryVariable>
                     </CustomVariable>

--- a/src/components/metrics/workloads/WorkloadPageCPU.tsx
+++ b/src/components/metrics/workloads/WorkloadPageCPU.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Stack, useStyles2 } from '@grafana/ui';
-import { VariableControl } from '@grafana/scenes-react';
+import { DataLayerControl, VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -21,6 +21,7 @@ export function WorkloadPageCPU() {
         <VariableControl name="node" />
         <VariableControl name="namespace" />
         <VariableControl name="pod" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 

--- a/src/components/metrics/workloads/WorkloadPageMemory.tsx
+++ b/src/components/metrics/workloads/WorkloadPageMemory.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Stack, useStyles2 } from '@grafana/ui';
-import { VariableControl } from '@grafana/scenes-react';
+import { DataLayerControl, VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -21,6 +21,7 @@ export function WorkloadPageMemory() {
         <VariableControl name="node" />
         <VariableControl name="namespace" />
         <VariableControl name="pod" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 

--- a/src/components/metrics/workloads/WorkloadPageNetwork.tsx
+++ b/src/components/metrics/workloads/WorkloadPageNetwork.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Stack, useStyles2 } from '@grafana/ui';
-import { VariableControl } from '@grafana/scenes-react';
+import { DataLayerControl, VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -18,6 +18,7 @@ export function WorkloadPageNetwork() {
         <VariableControl name="node" />
         <VariableControl name="namespace" />
         <VariableControl name="pod" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 

--- a/src/components/metrics/workloads/WorkloadPageOverview.tsx
+++ b/src/components/metrics/workloads/WorkloadPageOverview.tsx
@@ -9,8 +9,14 @@ import {
   VariableControl,
   useQueryRunner,
   VizPanel,
+  DataLayerControl,
 } from '@grafana/scenes-react';
 import { VizConfigBuilders } from '@grafana/scenes';
+import {
+  FieldColorModeId,
+  GraphDrawStyle,
+  StackingMode,
+} from '@grafana/schema';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -21,11 +27,6 @@ import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
 import { TimeSeriesWorkloadStatus } from '../shared/TimeSeriesWorkloadStatus';
-import {
-  FieldColorModeId,
-  GraphDrawStyle,
-  StackingMode,
-} from '@grafana/schema';
 
 interface Props {
   workloadType: string;
@@ -45,6 +46,7 @@ export function WorkloadPageOverview({ workloadType }: Props) {
         <VariableControl name="workloadtype" />
         <VariableControl name="workload" />
         <VariableControl name="pod" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 

--- a/src/components/metrics/workloads/WorkloadPageStorage.tsx
+++ b/src/components/metrics/workloads/WorkloadPageStorage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Stack, useStyles2 } from '@grafana/ui';
-import { VariableControl } from '@grafana/scenes-react';
+import { DataLayerControl, VariableControl } from '@grafana/scenes-react';
 
 import { getStyles } from '../../../utils/utils.styles';
 import { queries } from '../queries';
@@ -20,6 +20,7 @@ export function WorkloadPageStorage() {
         <VariableControl name="node" />
         <VariableControl name="namespace" />
         <VariableControl name="pod" />
+        <DataLayerControl name="Restarts" />
         <div className={styles.dashboard.header.spacer} />
       </div>
 


### PR DESCRIPTION
Add a restarts annotation to the details pages for workloads and pods,
which shows when a pod was restarted.
