### PR TITLE
Fix Inventory Entries in Kustomizations

### DIFF
--- a/src/datasource/components/flux/overview/Kustomization.tsx
+++ b/src/datasource/components/flux/overview/Kustomization.tsx
@@ -161,7 +161,7 @@ export function Kustomization({ datasource, namespace, manifest }: Props) {
             title={selectedResource.kind}
             datasource={datasource}
             resourceId={selectedResource.resourceId}
-            namespace={namespace || '*'}
+            namespace={selectedResource.namespace || '*'}
             parameterName="fieldSelector"
             parameterValue={`metadata.name=${selectedResource.name}`}
             onClose={() => setSelectedResource(undefined)}


### PR DESCRIPTION
The inventory entries in the Flux Kustomization details were not
properly linked, because the wrong namespace was used. This should be
fixed now.
