### PR TITLE
Add Cost Metrics

### DIFF
--- a/src/components/metrics/MetricsPage.tsx
+++ b/src/components/metrics/MetricsPage.tsx
@@ -19,6 +19,7 @@ import datasourcePluginJson from '../../datasource/plugin.json';
 import { StatWithFixedColorAndLink } from './shared/StatWithFixedColorAndLink';
 import { queries, variableQuery } from './queries';
 import { TimeSeriesMemoryOrCPU } from './shared/TimeSeriesMemoryOrCPU';
+import { RowCosts } from './shared/RowCosts';
 
 export function MetricsPage() {
   const styles = useStyles2(getStyles);
@@ -151,6 +152,14 @@ export function MetricsPage() {
                         usageExpr={queries.cluster.memoryUsage}
                       />
                     </div>
+                    <RowCosts
+                      costsCPUAllocation={queries.cluster.costsCPUAllocation}
+                      costsMemoryAllocation={
+                        queries.cluster.costsMemoryAllocation
+                      }
+                      costsCPUIdle={queries.cluster.costsCPUIdle}
+                      costsMemoryIdle={queries.cluster.costsMemoryIdle}
+                    />
                   </Stack>
                 </Stack>
               </PluginPage>

--- a/src/components/metrics/namespaces/NamespacePageOverview.tsx
+++ b/src/components/metrics/namespaces/NamespacePageOverview.tsx
@@ -15,6 +15,7 @@ import { TableKubernetesResource } from '../shared/TableKubernetesResource';
 import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+import { RowCosts } from '../shared/RowCosts';
 
 export function NamespacePageOverview() {
   const styles = useStyles2(getStyles);
@@ -49,6 +50,13 @@ export function NamespacePageOverview() {
           usageExpr={queries.namespaces.memoryUsage}
         />
       </div>
+
+      <RowCosts
+        costsCPUAllocation={queries.namespaces.costsCPUAllocation}
+        costsMemoryAllocation={queries.namespaces.costsMemoryAllocation}
+        costsCPUIdle={queries.namespaces.costsCPUIdle}
+        costsMemoryIdle={queries.namespaces.costsMemoryIdle}
+      />
 
       <Workloads />
     </Stack>

--- a/src/components/metrics/nodes/NodePageOverview.tsx
+++ b/src/components/metrics/nodes/NodePageOverview.tsx
@@ -15,6 +15,7 @@ import { TableKubernetesResource } from '../shared/TableKubernetesResource';
 import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+import { RowCosts } from '../shared/RowCosts';
 
 export function NodePageOverview() {
   const styles = useStyles2(getStyles);
@@ -50,6 +51,13 @@ export function NodePageOverview() {
           usageExpr={queries.nodes.memoryUsage}
         />
       </div>
+
+      <RowCosts
+        costsCPUAllocation={queries.nodes.costsCPUAllocation}
+        costsMemoryAllocation={queries.nodes.costsMemoryAllocation}
+        costsCPUIdle={queries.nodes.costsCPUIdle}
+        costsMemoryIdle={queries.nodes.costsMemoryIdle}
+      />
 
       <Pods />
     </Stack>

--- a/src/components/metrics/pods/PodPageOverview.tsx
+++ b/src/components/metrics/pods/PodPageOverview.tsx
@@ -8,6 +8,7 @@ import { TableResourceUsage } from '../shared/TableResourceUsage';
 import { LegendResourceUsage } from '../shared/LegendResourceUsage';
 import { TableKubernetesResource } from '../shared/TableKubernetesResource';
 import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { RowCosts } from '../shared/RowCosts';
 
 export function PodPageOverview() {
   const styles = useStyles2(getStyles);
@@ -43,6 +44,13 @@ export function PodPageOverview() {
           usageExpr={queries.pods.memoryUsage}
         />
       </div>
+
+      <RowCosts
+        costsCPUAllocation={queries.pods.costsCPUAllocation}
+        costsMemoryAllocation={queries.pods.costsMemoryAllocation}
+        costsCPUIdle={queries.pods.costsCPUIdle}
+        costsMemoryIdle={queries.pods.costsMemoryIdle}
+      />
 
       <Containers />
     </Stack>

--- a/src/components/metrics/queries.ts
+++ b/src/components/metrics/queries.ts
@@ -96,6 +96,145 @@ export const queries = {
     "instance"
   )
 )`,
+    costsCPUAllocation: `sum_over_time(
+  sum(
+    max(
+      kube_node_status_capacity{
+        cluster=~"$cluster",resource=~"cpu"
+      }
+    ) by(cluster,node,resource)
+      * on(cluster,node) group_left()
+    max(
+      node_cpu_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsMemoryAllocation: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          max(
+            kube_node_status_capacity{
+              cluster=~"$cluster",resource=~"memory"
+            }
+          ) by(cluster,node,resource)
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_ram_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsCPUIdle: `sum_over_time(
+  sum(
+    label_replace(
+      sum(
+        label_join(
+          (
+            sum(
+              max(
+                (
+                  1
+                    -
+                  rate(
+                    node_cpu_seconds_total{
+                      cluster=~"$cluster",mode=~"idle"
+                    }[$__rate_interval]
+                  )
+                )
+                  >=
+                0
+              ) by(cluster,instance,cpu,core)
+            ) by(cluster,instance)
+              or
+            sum(
+              rate(
+                node_cpu_usage_seconds_total{
+                  cluster=~"$cluster"
+                }[$__rate_interval]
+              )
+                >=
+              0
+            ) by(cluster,instance)
+          )
+            or
+          sum(
+            label_join(
+              label_join(
+                rate(
+                  k8s_node_cpu_time_seconds_total{
+                    k8s_cluster_name=~"$cluster"
+                  }[$__rate_interval]
+                ),
+                "cluster",
+                ",",
+                "k8s_cluster_name"
+              ),
+              "instance",
+              ",",
+              "k8s_node_name"
+            )
+          ) by(cluster,instance),
+          "node",
+          ",",
+          "instance"
+        )
+      ) by(cluster,instance),
+      "node",
+      "$1",
+      "instance",
+      "([^:]+).*"
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_cpu_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsMemoryIdle: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          max(
+            label_replace(
+              windows_memory_available_bytes{
+                cluster=~"$cluster"
+              }
+                or
+              node_memory_MemAvailable_bytes{
+                cluster=~"$cluster"
+              },
+              "node",
+              "$1",
+              "instance",
+              "([^:]+).*"
+            )
+          ) by(cluster,node)
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_ram_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
   },
   nodes: {
     info: `avg_over_time(
@@ -910,6 +1049,227 @@ sum(
     }[$__rate_interval]
   )
 ) by(node)`,
+    costsCPUAllocation: `sum_over_time(
+  (
+    max(
+      max(
+        kube_node_status_capacity{
+          cluster=~"$cluster",
+          node=~"$node(:[0-9]{2,5})?",
+          resource=~"cpu"
+        }
+      ) by(cluster,node,resource)
+    )
+      *
+    sum(
+      max(
+        node_cpu_hourly_cost{
+          cluster=~"$cluster",
+          node=~"$node(:[0-9]{2,5})?"
+        }
+      ) by(cluster,node)
+    )
+  )[$__range:1h]
+)`,
+    costsMemoryAllocation: `sum_over_time(
+  (
+    (
+      (
+        (
+          max(
+            max(
+              kube_node_status_capacity{
+                cluster=~"$cluster",
+                node=~"$node(:[0-9]{2,5})?",
+                resource=~"memory"
+              }
+            ) by(cluster,node,resource)
+          )
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      *
+    sum(
+      node_ram_hourly_cost{
+        cluster=~"$cluster",
+        node=~"$node(:[0-9]{2,5})?"
+      }
+    )
+  )[$__range:1h]
+)`,
+    costsCPUIdle: `sum_over_time(
+  sum(
+    label_replace(
+      sum(
+        label_join(
+          (
+            sum(
+              max(
+                (
+                  1
+                    -
+                  rate(
+                    node_cpu_seconds_total{
+                      cluster=~"$cluster",
+                      instance=~"$node(:[0-9]{2,5})?",
+                      mode=~"idle"
+                    }[$__rate_interval]
+                  )
+                )
+                  >=
+                0
+              ) by(cluster,instance,cpu,core)
+            ) by(cluster,instance)
+              or
+            sum(
+              rate(
+                node_cpu_usage_seconds_total{
+                  cluster=~"$cluster",
+                  instance=~"$node(:[0-9]{2,5})?"
+                }[$__rate_interval]
+              )
+                >=
+              0
+            ) by(cluster,instance)
+          )
+            or
+          sum(
+            label_join(
+              label_join(
+                rate(
+                  k8s_node_cpu_time_seconds_total{
+                    k8s_cluster_name=~"$cluster"
+                  }[$__rate_interval]
+                ),
+                "cluster",
+                ",",
+                "k8s_cluster_name"
+              ),
+              "instance",
+              ",",
+              "k8s_node_name"
+            )
+          ) by(cluster,instance),
+          "node",
+          ",",
+          "instance"
+        )
+          or
+        label_join(
+          (
+            sum(
+              max(
+                (
+                  1
+                    -
+                  rate(
+                    node_cpu_seconds_total{
+                      cluster=~"$cluster",
+                      node=~"$node(:[0-9]{2,5})?",
+                      mode=~"idle"
+                    }[$__rate_interval]
+                  )
+                )
+                  >=
+                0
+              ) by(cluster,instance,cpu,core)
+            ) by(cluster,instance)
+              or
+            sum(
+              rate(
+                node_cpu_usage_seconds_total{
+                  cluster=~"$cluster",
+                  node=~"$node(:[0-9]{2,5})?"
+                }[$__rate_interval]
+              )
+                >=
+              0
+            ) by(cluster,instance)
+          )
+            or
+          sum(
+            label_join(
+              label_join(
+                rate(
+                  k8s_node_cpu_time_seconds_total{
+                    k8s_cluster_name=~"$cluster",
+                    k8s_node_name=~"$node(:[0-9]{2,5})?"
+                  }[$__rate_interval]
+                ),
+                "cluster",
+                ",",
+                "k8s_cluster_name"
+              ),
+              "instance",
+              ",",
+              "k8s_node_name"
+            )
+          ) by(cluster,instance),
+          "node",
+          ",",
+          "instance"
+        )
+      ) by(cluster,node,instance),
+      "node",
+      "$1",
+      "instance",
+      "([^:]+).*"
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_cpu_hourly_cost{
+        cluster=~"$cluster",
+        node=~"$node(:[0-9]{2,5})?"
+      }
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsMemoryIdle: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          max(
+            label_replace(
+              windows_memory_available_bytes{
+                cluster=~"$cluster",
+                instance=~"$node(:[0-9]{2,5})?"
+              }
+                or
+              node_memory_MemAvailable_bytes{
+                cluster=~"$cluster",
+                instance=~"$node(:[0-9]{2,5})?"
+              },
+              "node",
+              "$1",
+              "instance",
+              "([^:]+).*"
+            )
+          ) by(cluster,node)
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_ram_hourly_cost{
+        cluster=~"$cluster",
+        node=~"$node(:[0-9]{2,5})?"
+      }
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
   },
   namespaces: {
     labelsByCluster: `label_values(kube_namespace_status_phase{cluster=~"$cluster"}, namespace)`,
@@ -1337,6 +1697,218 @@ sum(
     }[$__rate_interval]
   )
 ) by(namespace)`,
+    costsCPUAllocation: `sum_over_time(
+  sum(
+    max(
+      sum(
+        kube_pod_container_resource_requests{
+          cluster=~"$cluster",
+          namespace="$namespace",
+          container!="POD",
+          container!="",
+          resource="cpu"
+        }
+      ) by(cluster,namespace,node,resource)
+        or
+      sum(
+        max(
+          rate(
+            container_cpu_usage_seconds_total{
+              cluster=~"$cluster",
+              namespace="$namespace",
+              node!="",
+              container!="POD",
+              container!=""
+            }[$__rate_interval]
+          )
+            or
+          label_replace(
+            rate(
+              container_cpu_usage_seconds_total{
+                cluster=~"$cluster",
+                namespace="$namespace",
+                node="",
+                container!="POD",
+                container!=""
+              }[$__rate_interval]
+            ),
+            "node",
+            "$1",
+            "instance",
+            "([^:]+).*"
+          )
+        ) by(cluster,namespace,node,pod,container)
+      ) by(cluster,namespace,node)
+    ) by(cluster,namespace,node)
+      * on(cluster,node) group_left()
+    max(
+      node_cpu_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsMemoryAllocation: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          max(
+            sum(
+              kube_pod_container_resource_requests{
+                cluster=~"$cluster",
+                namespace="$namespace",
+                container!="POD",
+                container!="",
+                resource="memory"
+              }
+            ) by(cluster,node,resource)
+              or
+            sum(
+              max(
+                container_memory_working_set_bytes{
+                  cluster=~"$cluster",
+                  namespace="$namespace",
+                  node!="",
+                  container!="POD",
+                  container!=""
+                }
+                  or
+                label_replace(
+                  container_memory_working_set_bytes{
+                    cluster=~"$cluster",
+                    namespace="$namespace",
+                    node="",
+                    container!="POD",
+                    container!=""
+                  },
+                  "node",
+                  "$1",
+                  "instance",
+                  "([^:]+).*"
+                )
+              ) by(cluster,namespace,node,pod,container)
+            ) by(cluster,node)
+          ) by(cluster,node)
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_ram_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsCPUIdle: `sum_over_time(
+  sum(
+    (
+      sum(
+        kube_pod_container_resource_requests{
+          cluster=~"$cluster",
+          namespace="$namespace",
+          container!="POD",
+          container!="",
+          resource="cpu"
+        }
+      ) by(cluster,node,resource)
+        - on(cluster,node) group_left()
+      sum(
+        max(
+          rate(
+            container_cpu_usage_seconds_total{
+              cluster=~"$cluster",
+              namespace="$namespace",
+              node!="",
+              container!="POD",
+              container!=""
+            }[$__rate_interval]
+          )
+            or
+          label_replace(
+            rate(
+              container_cpu_usage_seconds_total{
+                cluster=~"$cluster",
+                namespace="$namespace",
+                node="",
+                container!="POD",
+                container!=""
+              }[$__rate_interval]
+            ),
+            "node",
+            "$1",
+            "instance",
+            "([^:]+).*"
+          )
+        ) by(cluster,namespace,node,pod,container)
+      ) by(cluster,node)
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_cpu_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsMemoryIdle: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          (
+            sum(
+              kube_pod_container_resource_requests{
+                cluster=~"$cluster",
+                namespace="$namespace",
+                container!="POD",
+                container!="",
+                resource="memory"
+              }
+            ) by(cluster,node)
+              - on(cluster,node) group_left()
+            sum(
+              max(
+                container_memory_working_set_bytes{
+                  cluster=~"$cluster",
+                  namespace="$namespace",
+                  node!="",
+                  container!="POD",
+                  container!=""
+                }
+                  or
+                label_replace(
+                  container_memory_working_set_bytes{
+                    cluster=~"$cluster",
+                    namespace="$namespace",
+                    node="",
+                    container!="POD",
+                    container!=""
+                  },
+                  "node",
+                  "$1",
+                  "instance",
+                  "([^:]+).*"
+                )
+              ) by(cluster,namespace,node,pod,container)
+            ) by(cluster,node)
+          )
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_ram_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
   },
   workloads: {
     labelsByClusterNamespace: `query_result(
@@ -3407,6 +3979,214 @@ label_join(
     ) by(cluster,namespace,pod)
   ) by(cluster,namespace,pod,workload,workload_type)
 ) by(workload,workload_type)`,
+    costsCPUAllocation: `sum_over_time(
+  sum(
+    max(
+      sum(
+        max(
+          kube_pod_container_resource_requests{
+            container!="POD",
+            container!="",
+            cluster=~"$cluster",
+            namespace=~"$namespace",
+            resource=~"cpu"
+          }
+        ) by(cluster,node,namespace,pod,container,resource)
+          * on(namespace,pod) group_left()
+        namespace_workload_pod:kube_pod_owner:relabel{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          workload=~"$workload",
+          workload_type=~"$workloadtype"
+        }
+      ) by(cluster,namespace,node,resource)
+        or
+      sum(
+        max(
+          node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+            container!="POD",
+            container!="",
+            cluster=~"$cluster",
+            namespace=~"$namespace"
+          }
+        ) by(cluster,namespace,node,pod,container)
+          * on(namespace,pod) group_left()
+        namespace_workload_pod:kube_pod_owner:relabel{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          workload=~"$workload",
+          workload_type=~"$workloadtype"
+        }
+      ) by(cluster,namespace,node)
+    ) by(cluster,namespace,node)
+      * on(cluster,node) group_left()
+    max(
+      node_cpu_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsMemoryAllocation: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          max(
+            sum(
+              max(
+                kube_pod_container_resource_requests{
+                  container!="POD",
+                  container!="",
+                  cluster=~"$cluster",
+                  namespace=~"$namespace",
+                  resource=~"memory"
+                }
+              ) by(cluster,node,namespace,pod,container,resource)
+                * on(namespace,pod) group_left()
+              namespace_workload_pod:kube_pod_owner:relabel{
+                cluster=~"$cluster",
+                namespace=~"$namespace",
+                workload=~"$workload",
+                workload_type=~"$workloadtype"
+              }
+            ) by(cluster,namespace,node,resource)
+              or
+            sum(
+              max(
+                node_namespace_pod_container:container_memory_working_set_bytes{
+                  container!="POD",
+                  container!="",
+                  cluster=~"$cluster",
+                  namespace=~"$namespace"
+                }
+              ) by(cluster,node,namespace,pod,container,image)
+                * on(namespace,pod) group_left()
+              namespace_workload_pod:kube_pod_owner:relabel{
+                cluster=~"$cluster",
+                namespace=~"$namespace",
+                workload=~"$workload",
+                workload_type=~"$workloadtype"
+              }
+            ) by(cluster,namespace,node)
+          ) by(cluster,namespace,node)
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_ram_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsCPUIdle: `sum_over_time(
+  sum(
+    (
+      sum(
+        max(
+          kube_pod_container_resource_requests{
+            container!="POD",
+            container!="",
+            cluster=~"$cluster",
+            namespace=~"$namespace",
+            resource=~"cpu"
+          }
+        ) by(cluster,node,namespace,pod,container,resource)
+          * on(namespace,pod) group_left()
+        namespace_workload_pod:kube_pod_owner:relabel{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          workload=~"$workload",
+          workload_type=~"$workloadtype"
+        }
+      ) by(cluster,namespace,node)
+        - on(cluster,namespace,node) group_left()
+      sum(
+        max(
+          node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
+            container!="POD",
+            container!="",
+            cluster=~"$cluster",
+            namespace=~"$namespace"
+          }
+        ) by(cluster,namespace,node,pod,container)
+          * on(namespace,pod) group_left()
+        namespace_workload_pod:kube_pod_owner:relabel{
+          cluster=~"$cluster",
+          namespace=~"$namespace",
+          workload=~"$workload",
+          workload_type=~"$workloadtype"
+        }
+      ) by(cluster,namespace,node)
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_cpu_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsMemoryIdle: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          (
+            sum(
+              max(
+                kube_pod_container_resource_requests{
+                  container!="POD",
+                  container!="",
+                  cluster=~"$cluster",
+                  namespace=~"$namespace",
+                  resource=~"memory"
+                }
+              ) by(cluster,node,namespace,pod,container,resource)
+                * on(namespace,pod) group_left()
+              namespace_workload_pod:kube_pod_owner:relabel{
+                cluster=~"$cluster",
+                namespace=~"$namespace",
+                workload=~"$workload",
+                workload_type=~"$workloadtype"
+              }
+            ) by(cluster,namespace,node)
+              - on(cluster,namespace,node) group_left()
+            sum(
+              max(
+                node_namespace_pod_container:container_memory_working_set_bytes{
+                  container!="POD",
+                  container!="",
+                  cluster=~"$cluster",
+                  namespace=~"$namespace"
+                }
+              ) by(cluster,node,namespace,pod,container,image)
+                * on(namespace,pod) group_left()
+              namespace_workload_pod:kube_pod_owner:relabel{
+                cluster=~"$cluster",
+                namespace=~"$namespace",
+                workload=~"$workload",
+                workload_type=~"$workloadtype"
+              }
+            ) by(cluster,namespace,node)
+          )
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_ram_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
   },
   pods: {
     count: `count(kube_pod_info{cluster=~"$cluster", namespace=~"$namespace", pod!=""})`,
@@ -4156,6 +4936,228 @@ sum(
     }[$__interval]
   )
 ) by(pod)`,
+    costsCPUAllocation: `sum_over_time(
+  sum(
+    max(
+      sum(
+        kube_pod_container_resource_requests{
+          cluster=~"$cluster",
+          namespace="$namespace",
+          pod="$pod",
+          container=~".+",
+          resource="cpu"
+        }
+      ) by(cluster,node,pod,resource)
+        or
+      sum(
+        max(
+          rate(
+            container_cpu_usage_seconds_total{
+              cluster=~"$cluster",
+              namespace="$namespace",
+              pod="$pod",
+              container=~".+",
+              node!=""
+            }[$__rate_interval]
+          )
+            or
+          label_replace(
+            rate(
+              container_cpu_usage_seconds_total{
+                cluster=~"$cluster",
+                namespace="$namespace",
+                pod="$pod",
+                container=~".+",
+                node=""
+              }[$__rate_interval]
+            ),
+            "node",
+            "$1",
+            "instance",
+            "([^:]+).*"
+          )
+        ) by(cluster,node,namespace,pod,container)
+      ) by(cluster,node,pod)
+    ) by(cluster,node,pod)
+      * on(cluster,node) group_left()
+    max(
+      node_cpu_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsMemoryAllocation: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          max(
+            sum(
+              kube_pod_container_resource_requests{
+                cluster=~"$cluster",
+                namespace="$namespace",
+                pod="$pod",
+                container=~".+",
+                resource="memory"
+              }
+            ) by(cluster,node,pod,resource)
+              or
+            sum(
+              max(
+                container_memory_working_set_bytes{
+                  cluster=~"$cluster",
+                  namespace="$namespace",
+                  pod="$pod",
+                  container=~".+",
+                  node!=""
+                }
+                  or
+                label_replace(
+                  container_memory_working_set_bytes{
+                    cluster=~"$cluster",
+                    namespace="$namespace",
+                    pod="$pod",
+                    container=~".+",
+                    node=""
+                  },
+                  "node",
+                  "$1",
+                  "instance",
+                  "([^:]+).*"
+                )
+              ) by(cluster,node,namespace,pod,container)
+            ) by(cluster,node,pod)
+          ) by(cluster,node,pod)
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_ram_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsCPUIdle: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          (
+            sum(
+              kube_pod_container_resource_requests{
+                cluster=~"$cluster",
+                namespace="$namespace",
+                pod="$pod",
+                container=~".+",
+                resource="memory"
+              }
+            ) by(cluster,pod)
+              - on(cluster,pod) group_left(node)
+            sum(
+              max(
+                rate(
+                  container_cpu_usage_seconds_total{
+                    cluster=~"$cluster",
+                    namespace="$namespace",
+                    pod="$pod",
+                    container=~".+",
+                    node!=""
+                  }[$__rate_interval]
+                )
+                  or
+                label_replace(
+                  rate(
+                    container_cpu_usage_seconds_total{
+                      cluster=~"$cluster",
+                      namespace="$namespace",
+                      pod="$pod",
+                      container=~".+",
+                      node=""
+                    }[$__rate_interval]
+                  ),
+                  "node",
+                  "$1",
+                  "instance",
+                  "([^:]+).*"
+                )
+              ) by(cluster,node,namespace,pod,container)
+            ) by(cluster,node,pod)
+          )
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(node_ram_hourly_cost{cluster=~"$cluster"}) by(cluster,node)
+  )[$__range:1h]
+)`,
+    costsMemoryIdle: `sum_over_time(
+  sum(
+    (
+      (
+        (
+          (
+            sum(
+              kube_pod_container_resource_requests{
+                cluster=~"$cluster",
+                namespace="$namespace",
+                pod="$pod",
+                container=~".+",
+                resource="memory"
+              }
+            ) by(cluster,pod)
+              - on(cluster,pod) group_left(node)
+            sum(
+              max(
+                container_memory_working_set_bytes{
+                  cluster=~"$cluster",
+                  namespace="$namespace",
+                  pod="$pod",
+                  container=~".+",
+                  node!=""
+                }
+                  or
+                label_replace(
+                  container_memory_working_set_bytes{
+                    cluster=~"$cluster",
+                    namespace="$namespace",
+                    pod="$pod",
+                    container=~".+",
+                    node=""
+                  },
+                  "node",
+                  "$1",
+                  "instance",
+                  "([^:]+).*"
+                )
+              ) by(cluster,node,namespace,pod,container)
+            ) by(cluster,node,pod)
+          )
+            /
+          1024
+        )
+          /
+        1024
+      )
+        /
+      1024
+    )
+      * on(cluster,node) group_left()
+    max(
+      node_ram_hourly_cost{cluster=~"$cluster"}
+    ) by(cluster,node)
+  )[$__range:1h]
+)`,
   },
   containers: {
     labelsByClusterNamespacePod: `label_values(

--- a/src/components/metrics/shared/RowCosts.tsx
+++ b/src/components/metrics/shared/RowCosts.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { useStyles2 } from '@grafana/ui';
+import { VizConfigBuilders } from '@grafana/scenes';
+import { useQueryRunner, VizPanel } from '@grafana/scenes-react';
+import { FieldColorModeId, MappingType } from '@grafana/schema';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+
+interface Props {
+  costsCPUAllocation: string;
+  costsMemoryAllocation: string;
+  costsCPUIdle: string;
+  costsMemoryIdle: string;
+}
+
+export function RowCosts({
+  costsCPUAllocation,
+  costsMemoryAllocation,
+  costsCPUIdle,
+  costsMemoryIdle,
+}: Props) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.dashboard.row.height100px}>
+      <SingleStat
+        title="CPU Allocation Costs"
+        description="Allocation is the greater amount of either the actual CPU usage or the requested amount. The sum of the CPU allocation in each hour is multiplied by the hourly CPU cost, which is estimated by OpenCost."
+        refId="cpu"
+        expr={costsCPUAllocation}
+      />
+      <SingleStat
+        title="Memory Allocation Costs"
+        description="Allocation is the greater amount of either the actual memory usage or the requested amount. The sum of the memory allocation in each hour is multiplied by the hourly memory cost, which is estimated by OpenCost."
+        refId="memory"
+        expr={costsMemoryAllocation}
+      />
+      <SingleStat
+        title="Total Allocation Costs"
+        description="Allocation is the greater amount of either the actual CPU and memory usage or the requested amount. The sum of the CPU and memory allocation in each hour is multiplied by the hourly CPU and memory cost, which is estimated by OpenCost."
+        refId="total"
+        expr={`(${costsCPUAllocation}) + (${costsMemoryAllocation})`}
+      />
+      <SingleStat
+        title="CPU Idle Costs"
+        description={`For Nodes and Clusters, idle cost is the difference between usage and physical capacity. For resources not at the Node or Cluster level, idle cost is the difference between usage and requests. Requests act as reserved resources, so unused requests can't be used by other objects in Kubernetes.
+
+"Undersized" means that usage is greater than requests, so it is not possible to calculate the idle cost.`}
+        refId="cpu"
+        expr={costsCPUIdle}
+      />
+      <SingleStat
+        title="Memory Idle Costs"
+        description={`For Nodes and Clusters, idle cost is the difference between usage and physical capacity. For resources not at the Node or Cluster level, idle cost is the difference between usage and requests. Requests act as reserved resources, so unused requests can't be used by other objects in Kubernetes.
+
+"Undersized" means that usage is greater than requests, so it is not possible to calculate the idle cost.`}
+        refId="memory"
+        expr={costsMemoryIdle}
+      />
+      <SingleStat
+        title="Total Idle Costs"
+        description={`For Nodes and Clusters, idle cost is the difference between usage and physical capacity. For resources not at the Node or Cluster level, idle cost is the difference between usage and requests. Requests act as reserved resources, so unused requests can't be used by other objects in Kubernetes.
+
+"Undersized" means that usage is greater than requests, so it is not possible to calculate the idle cost.`}
+        refId="total"
+        expr={`(${costsCPUIdle}) + (${costsMemoryIdle})`}
+      />
+    </div>
+  );
+}
+
+function SingleStat({
+  title,
+  description,
+  refId,
+  expr,
+}: {
+  title: string;
+  description: string;
+  refId: string;
+  expr: string;
+}) {
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: [
+      {
+        refId: refId,
+        format: 'time_series',
+        instant: true,
+        expr: expr,
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.stat()
+    .setUnit('currencyUSD')
+    .setColor({
+      mode: FieldColorModeId.Fixed,
+      fixedColor: 'text',
+    })
+    .setMappings([
+      {
+        options: {
+          from: null,
+          to: 0,
+          result: {
+            text: 'Undersized',
+            index: 0,
+          },
+        },
+        type: MappingType.RangeToText,
+      },
+    ])
+
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title={title}
+      description={description}
+      menu={menu}
+      viz={viz}
+      dataProvider={dataProvider}
+    />
+  );
+}

--- a/src/components/metrics/workloads/WorkloadPageOverview.tsx
+++ b/src/components/metrics/workloads/WorkloadPageOverview.tsx
@@ -27,6 +27,7 @@ import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
 import { TimeSeriesWorkloadStatus } from '../shared/TimeSeriesWorkloadStatus';
+import { RowCosts } from '../shared/RowCosts';
 
 interface Props {
   workloadType: string;
@@ -240,6 +241,13 @@ export function WorkloadPageOverview({ workloadType }: Props) {
           />
         )}
       </div>
+
+      <RowCosts
+        costsCPUAllocation={queries.workloads.costsCPUAllocation}
+        costsMemoryAllocation={queries.workloads.costsMemoryAllocation}
+        costsCPUIdle={queries.workloads.costsCPUIdle}
+        costsMemoryIdle={queries.workloads.costsMemoryIdle}
+      />
 
       <Pods />
 


### PR DESCRIPTION
Add costs for CPU and Memory to the overview pages for the cluster,
nodes, namespaces, workloads and pods. The costs are calculated using
the OpenCost metrics.

Next to the actual costs, we also show the idle costs for the cluster,
nodes, namespaces, workloads and pods. The cluster and node idle costs
are calculated based on the capacity and the actual usage. The idle
costs for namespaces, workloads and pods are calculated based on the
requests and the actual usage.
