### PR TITLE
Extend Cost Integration

### DIFF
--- a/src/components/metrics/metrics/MetricsPage.tsx
+++ b/src/components/metrics/metrics/MetricsPage.tsx
@@ -8,6 +8,7 @@ import {
   QueryVariable,
   TimeRangePicker,
   RefreshPicker,
+  CustomVariable,
 } from '@grafana/scenes-react';
 
 import pluginJson from '../../../plugin.json';
@@ -16,6 +17,7 @@ import { getStyles } from '../../../utils/utils.styles';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { queries, variableQuery } from '../queries';
 import { MetricsPageOverview } from './MetricsPageOverview';
+import { MetricsPageCost } from './MetricsPageCost';
 
 export function MetricsPage() {
   const styles = useStyles2(getStyles);
@@ -58,57 +60,90 @@ export function MetricsPage() {
             refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
-            <QueryVariable
-              name="namespace"
-              label="Namespace"
-              datasource={{
-                type: 'prometheus',
-                uid: '$prometheus',
-              }}
-              query={{
-                refId: 'namespaces',
-                query: variableQuery(queries.namespaces.labelsByCluster),
-              }}
-              refresh={VariableRefresh.onTimeRangeChanged}
-              isMulti={true}
-              includeAll={true}
-              initialValue={'$__all'}
-              allValue=".+"
-              sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+            <CustomVariable
+              name="node"
+              label="Node"
+              query=".+"
+              initialValue=".+"
+              hide={VariableHide.hideVariable}
             >
-              <PluginPage
-                renderTitle={() => (
-                  <Stack gap={0} alignItems="center" direction="row">
-                    <img
-                      className={styles.pluginPage.title.image}
-                      alt="Metrics"
-                      src={resourcesImg}
-                    />
-                    <h1>Metrics</h1>
-                  </Stack>
-                )}
-                subTitle={pluginJson.info.description}
-                actions={
-                  <>
-                    <TimeRangePicker />
-                    <RefreshPicker />
-                  </>
-                }
+              <QueryVariable
+                name="namespace"
+                label="Namespace"
+                datasource={{
+                  type: 'prometheus',
+                  uid: '$prometheus',
+                }}
+                query={{
+                  refId: 'namespaces',
+                  query: variableQuery(queries.namespaces.labelsByCluster),
+                }}
+                refresh={VariableRefresh.onTimeRangeChanged}
+                isMulti={true}
+                includeAll={true}
+                initialValue={'$__all'}
+                allValue=".+"
+                sort={VariableSort.alphabeticalCaseInsensitiveAsc}
               >
-                <TabsBar className={styles.dashboard.tabsBar}>
-                  <Tab
-                    label="Overview"
-                    active={activeTab === 'overview'}
-                    onChangeTab={(ev) => {
-                      ev?.preventDefault();
-                      setActiveTab('overview');
-                    }}
-                  />
-                </TabsBar>
+                <CustomVariable
+                  name="workloadtype"
+                  label="Workload Type"
+                  query=".+"
+                  initialValue=".+"
+                  hide={VariableHide.hideVariable}
+                >
+                  <CustomVariable
+                    name="workload"
+                    label="Workload"
+                    query=".+"
+                    initialValue=".+"
+                    hide={VariableHide.hideVariable}
+                  >
+                    <PluginPage
+                      renderTitle={() => (
+                        <Stack gap={0} alignItems="center" direction="row">
+                          <img
+                            className={styles.pluginPage.title.image}
+                            alt="Metrics"
+                            src={resourcesImg}
+                          />
+                          <h1>Metrics</h1>
+                        </Stack>
+                      )}
+                      subTitle={pluginJson.info.description}
+                      actions={
+                        <>
+                          <TimeRangePicker />
+                          <RefreshPicker />
+                        </>
+                      }
+                    >
+                      <TabsBar className={styles.dashboard.tabsBar}>
+                        <Tab
+                          label="Overview"
+                          active={activeTab === 'overview'}
+                          onChangeTab={(ev) => {
+                            ev?.preventDefault();
+                            setActiveTab('overview');
+                          }}
+                        />
+                        <Tab
+                          label="Cost"
+                          active={activeTab === 'cost'}
+                          onChangeTab={(ev) => {
+                            ev?.preventDefault();
+                            setActiveTab('cost');
+                          }}
+                        />
+                      </TabsBar>
 
-                {activeTab === 'overview' && <MetricsPageOverview />}
-              </PluginPage>
-            </QueryVariable>
+                      {activeTab === 'overview' && <MetricsPageOverview />}
+                      {activeTab === 'cost' && <MetricsPageCost />}
+                    </PluginPage>
+                  </CustomVariable>
+                </CustomVariable>
+              </QueryVariable>
+            </CustomVariable>
           </QueryVariable>
         </QueryVariable>
       </DataSourceVariable>

--- a/src/components/metrics/metrics/MetricsPageCost.tsx
+++ b/src/components/metrics/metrics/MetricsPageCost.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { VariableControl } from '@grafana/scenes-react';
+
+import { getStyles } from '../../../utils/utils.styles';
+import { queries } from '../queries';
+import { StatCosts } from '../shared/StatCosts';
+import { TableCostsTop } from '../shared/TableCostsTop';
+
+export function MetricsPageCost() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <VariableControl name="prometheus" />
+        <VariableControl name="cluster" />
+        <VariableControl name="namespace" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+      <Stack direction="column" gap={2}>
+        <div className={styles.dashboard.row.height100px}>
+          <StatCosts
+            title="Total Cost Prior 30-day"
+            description="Total spend for the 30 days prior the current 30-day window."
+            refId="totalPrior30d"
+            expr={queries.cluster.costsTotalPrior30d}
+          />
+          <StatCosts
+            title="Total Cost Current 30-day"
+            description="Total spend for the previous 30-day window."
+            refId="totalCurrent30d"
+            expr={queries.cluster.costsTotalCurrent30d}
+          />
+          <StatCosts
+            title="Avg. Cost per Pod"
+            description="Average spend per pod for the previous 30-day window."
+            refId="perPodCurrent30d"
+            expr={queries.cluster.costsPerPodCurrent30d}
+          />
+          <StatCosts
+            title="Potential Savings"
+            description="The potential savings for 30 days after the current date, if CPU, memory, GPU and storage are optimized."
+            refId="potentialSavingsUsage"
+            expr={queries.cluster.costsPotentialSavings}
+          />
+        </div>
+        <div className={styles.dashboard.row.height400px}>
+          <TableCostsTop
+            title="Top Namespaces"
+            cpuAllocationExpr={queries.namespaces.costsCPUAllocation}
+            memoryAllocationExpr={queries.namespaces.costsMemoryAllocation}
+          />
+          <TableCostsTop
+            title="Top Workloads"
+            cpuAllocationExpr={queries.workloads.costsCPUAllocation}
+            memoryAllocationExpr={queries.workloads.costsMemoryAllocation}
+          />
+        </div>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/components/metrics/metrics/MetricsPageOverview.tsx
+++ b/src/components/metrics/metrics/MetricsPageOverview.tsx
@@ -17,6 +17,7 @@ import { RowCosts } from '../shared/RowCosts';
 import { LegendResourceUsage } from '../shared/LegendResourceUsage';
 import { TableResourceUsage } from '../shared/TableResourceUsage';
 import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+import { TableCosts } from '../shared/TableCosts';
 
 export function MetricsPageOverview() {
   const styles = useStyles2(getStyles);
@@ -102,6 +103,7 @@ function Nodes() {
           <RadioButtonGroup
             options={[
               { label: 'Usage', value: 'usage' },
+              { label: 'Cost', value: 'cost' },
               { label: 'Info', value: 'info' },
             ]}
             value={selected}
@@ -127,6 +129,15 @@ function Nodes() {
               memoryUsageMaxPercentExpr={
                 queries.nodes.memoryUsageMaxPercentOverTime
               }
+            />
+          )}
+          {selected === 'cost' && (
+            <TableCosts
+              title="Nodes"
+              cpuAllocationExpr={queries.nodes.costsCPUAllocation}
+              memoryAllocationExpr={queries.nodes.costsMemoryAllocation}
+              cpuIdleExpr={queries.nodes.costsCPUIdle}
+              memoryIdleExpr={queries.nodes.costsMemoryIdle}
             />
           )}
           {selected === 'info' && <TableKubernetesPods />}

--- a/src/components/metrics/namespaces/NamespacePage.tsx
+++ b/src/components/metrics/namespaces/NamespacePage.tsx
@@ -94,150 +94,160 @@ export function NamespacePage() {
                 initialValue={namespace}
                 hide={VariableHide.hideVariable}
               >
-                <QueryVariable
-                  name="workload"
-                  label="Workload"
-                  datasource={{
-                    type: 'prometheus',
-                    uid: '$prometheus',
-                  }}
-                  query={{
-                    refId: 'workloads',
-                    query: variableQuery(
-                      queries.workloads.labelsByClusterNamespace,
-                    ),
-                  }}
-                  refresh={VariableRefresh.onTimeRangeChanged}
-                  isMulti={true}
-                  includeAll={true}
-                  initialValue={'$__all'}
-                  allValue=".+"
-                  regex={`/workload="(?<value>[^"]+)/`}
-                  sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+                <CustomVariable
+                  name="workloadtype"
+                  label="Workload Type"
+                  query=".+"
+                  initialValue=".+"
+                  hide={VariableHide.hideVariable}
                 >
-                  <CustomVariable
-                    name="pod"
-                    label="Pod"
-                    query=".+"
-                    initialValue=".+"
-                    hide={VariableHide.hideVariable}
+                  <QueryVariable
+                    name="workload"
+                    label="Workload"
+                    datasource={{
+                      type: 'prometheus',
+                      uid: '$prometheus',
+                    }}
+                    query={{
+                      refId: 'workloads',
+                      query: variableQuery(
+                        queries.workloads.labelsByClusterNamespace,
+                      ),
+                    }}
+                    refresh={VariableRefresh.onTimeRangeChanged}
+                    isMulti={true}
+                    includeAll={true}
+                    initialValue={'$__all'}
+                    allValue=".+"
+                    regex={`/workload="(?<value>[^"]+)/`}
+                    sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                   >
-                    <QueryVariable
-                      name="pvc"
-                      label="PersistentVolumeClaim"
-                      datasource={{
-                        type: 'prometheus',
-                        uid: '$prometheus',
-                      }}
-                      query={{
-                        refId: 'pvcs',
-                        query: variableQuery(
-                          queries.persistentVolumeClaims
-                            .labelsByClusterNamespacePod,
-                        ),
-                      }}
-                      refresh={VariableRefresh.onTimeRangeChanged}
-                      isMulti={true}
-                      includeAll={true}
-                      initialValue={'$__all'}
-                      sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+                    <CustomVariable
+                      name="pod"
+                      label="Pod"
+                      query=".+"
+                      initialValue=".+"
+                      hide={VariableHide.hideVariable}
                     >
-                      <PluginPage
-                        pageNav={{
-                          text: namespace,
-                          parentItem: {
-                            text: 'Namespaces',
-                            url: prefixRoute(ROUTES.MetricsNamespaces),
-                          },
+                      <QueryVariable
+                        name="pvc"
+                        label="PersistentVolumeClaim"
+                        datasource={{
+                          type: 'prometheus',
+                          uid: '$prometheus',
                         }}
-                        renderTitle={() => (
-                          <Stack gap={0} alignItems="center" direction="row">
-                            <img
-                              className={styles.pluginPage.title.image}
-                              alt={namespace}
-                              src={resourcesImg}
-                            />
-                            <h1>{namespace}</h1>
-                            <Badge
-                              className={styles.pluginPage.title.badge}
-                              color="blue"
-                              text="namespace"
-                            />
-                          </Stack>
-                        )}
-                        subTitle={pluginJson.info.description}
-                        actions={
-                          <>
-                            <TimeRangePicker />
-                            <RefreshPicker />
-                          </>
-                        }
+                        query={{
+                          refId: 'pvcs',
+                          query: variableQuery(
+                            queries.persistentVolumeClaims
+                              .labelsByClusterNamespacePod,
+                          ),
+                        }}
+                        refresh={VariableRefresh.onTimeRangeChanged}
+                        isMulti={true}
+                        includeAll={true}
+                        initialValue={'$__all'}
+                        sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                       >
-                        <TabsBar className={styles.dashboard.tabsBar}>
-                          <Tab
-                            label="Overview"
-                            active={activeTab === 'overview'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('overview');
-                            }}
-                          />
-                          <Tab
-                            label="CPU"
-                            active={activeTab === 'cpu'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('cpu');
-                            }}
-                          />
-                          <Tab
-                            label="Memory"
-                            active={activeTab === 'memory'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('memory');
-                            }}
-                          />
-                          <Tab
-                            label="Network"
-                            active={activeTab === 'network'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('network');
-                            }}
-                          />
-                          <Tab
-                            label="Storage"
-                            active={activeTab === 'storage'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('storage');
-                            }}
-                          />
-                          <TabLogs
-                            resource="namespace"
-                            active={activeTab === 'logs'}
-                            onChangeTab={(ev) => {
-                              ev?.preventDefault();
-                              setActiveTab('logs');
-                            }}
-                          />
-                        </TabsBar>
-                        {activeTab === 'overview' && <NamespacePageOverview />}
-                        {activeTab === 'cpu' && <NamespacePageCPU />}
-                        {activeTab === 'memory' && <NamespacePageMemory />}
-                        {activeTab === 'network' && <NamespacePageNetwork />}
-                        {activeTab === 'storage' && <NamespacePageStorage />}
-                        {activeTab === 'logs' && (
-                          <TabLogsContent
-                            page="namespace"
-                            resource="namespace"
-                          />
-                        )}
-                      </PluginPage>
-                    </QueryVariable>
-                  </CustomVariable>
-                </QueryVariable>
+                        <PluginPage
+                          pageNav={{
+                            text: namespace,
+                            parentItem: {
+                              text: 'Namespaces',
+                              url: prefixRoute(ROUTES.MetricsNamespaces),
+                            },
+                          }}
+                          renderTitle={() => (
+                            <Stack gap={0} alignItems="center" direction="row">
+                              <img
+                                className={styles.pluginPage.title.image}
+                                alt={namespace}
+                                src={resourcesImg}
+                              />
+                              <h1>{namespace}</h1>
+                              <Badge
+                                className={styles.pluginPage.title.badge}
+                                color="blue"
+                                text="namespace"
+                              />
+                            </Stack>
+                          )}
+                          subTitle={pluginJson.info.description}
+                          actions={
+                            <>
+                              <TimeRangePicker />
+                              <RefreshPicker />
+                            </>
+                          }
+                        >
+                          <TabsBar className={styles.dashboard.tabsBar}>
+                            <Tab
+                              label="Overview"
+                              active={activeTab === 'overview'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('overview');
+                              }}
+                            />
+                            <Tab
+                              label="CPU"
+                              active={activeTab === 'cpu'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('cpu');
+                              }}
+                            />
+                            <Tab
+                              label="Memory"
+                              active={activeTab === 'memory'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('memory');
+                              }}
+                            />
+                            <Tab
+                              label="Network"
+                              active={activeTab === 'network'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('network');
+                              }}
+                            />
+                            <Tab
+                              label="Storage"
+                              active={activeTab === 'storage'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('storage');
+                              }}
+                            />
+                            <TabLogs
+                              resource="namespace"
+                              active={activeTab === 'logs'}
+                              onChangeTab={(ev) => {
+                                ev?.preventDefault();
+                                setActiveTab('logs');
+                              }}
+                            />
+                          </TabsBar>
+                          {activeTab === 'overview' && (
+                            <NamespacePageOverview />
+                          )}
+                          {activeTab === 'cpu' && <NamespacePageCPU />}
+                          {activeTab === 'memory' && <NamespacePageMemory />}
+                          {activeTab === 'network' && <NamespacePageNetwork />}
+                          {activeTab === 'storage' && <NamespacePageStorage />}
+                          {activeTab === 'logs' && (
+                            <TabLogsContent
+                              page="namespace"
+                              resource="namespace"
+                            />
+                          )}
+                        </PluginPage>
+                      </QueryVariable>
+                    </CustomVariable>
+                  </QueryVariable>
+                </CustomVariable>
               </CustomVariable>
             </QueryVariable>
           </QueryVariable>

--- a/src/components/metrics/namespaces/NamespacePageOverview.tsx
+++ b/src/components/metrics/namespaces/NamespacePageOverview.tsx
@@ -16,6 +16,7 @@ import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
 import { RowCosts } from '../shared/RowCosts';
+import { TableCosts } from '../shared/TableCosts';
 
 export function NamespacePageOverview() {
   const styles = useStyles2(getStyles);
@@ -75,12 +76,15 @@ function Workloads() {
           <RadioButtonGroup
             options={[
               { label: 'Usage', value: 'usage' },
+              { label: 'Cost', value: 'cost' },
               { label: 'Info', value: 'info' },
             ]}
             value={selected}
             onChange={(value) => setSelected(value)}
           />
-          {selected === 'usage' && <VariableControl name="workload" />}
+          {(selected === 'usage' || selected === 'cost') && (
+            <VariableControl name="workload" />
+          )}
           <div className={styles.dashboard.header.spacer} />
           {selected === 'usage' && <LegendResourceUsage />}
         </div>
@@ -107,6 +111,15 @@ function Workloads() {
               desiredPodsExpr={queries.workloads.desiredPods}
               readyPodsExpr={queries.workloads.readyPods}
               alertsExpr={queries.workloads.alertsCount}
+            />
+          )}
+          {selected === 'cost' && (
+            <TableCosts
+              title="Workloads"
+              cpuAllocationExpr={queries.workloads.costsCPUAllocation}
+              memoryAllocationExpr={queries.workloads.costsMemoryAllocation}
+              cpuIdleExpr={queries.workloads.costsCPUIdle}
+              memoryIdleExpr={queries.workloads.costsMemoryIdle}
             />
           )}
           {selected === 'info' && <TableKubernetesWorkloads />}

--- a/src/components/metrics/nodes/NodePageOverview.tsx
+++ b/src/components/metrics/nodes/NodePageOverview.tsx
@@ -16,6 +16,7 @@ import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
 import datasourcePluginJson from '../../../datasource/plugin.json';
 import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
 import { RowCosts } from '../shared/RowCosts';
+import { TableCosts } from '../shared/TableCosts';
 
 export function NodePageOverview() {
   const styles = useStyles2(getStyles);
@@ -76,6 +77,7 @@ function Pods() {
           <RadioButtonGroup
             options={[
               { label: 'Usage', value: 'usage' },
+              { label: 'Cost', value: 'cost' },
               { label: 'Info', value: 'info' },
             ]}
             value={selected}
@@ -103,6 +105,15 @@ function Pods() {
                 queries.pods.memoryUsageMaxPercentOverTime
               }
               alertsExpr={queries.pods.alertsCount}
+            />
+          )}
+          {selected === 'cost' && (
+            <TableCosts
+              title="Pods"
+              cpuAllocationExpr={queries.pods.costsCPUAllocation}
+              memoryAllocationExpr={queries.pods.costsMemoryAllocation}
+              cpuIdleExpr={queries.pods.costsCPUIdle}
+              memoryIdleExpr={queries.pods.costsMemoryIdle}
             />
           )}
           {selected === 'info' && <TableKubernetesPods />}

--- a/src/components/metrics/queries.ts
+++ b/src/components/metrics/queries.ts
@@ -235,6 +235,152 @@ export const queries = {
     ) by(cluster,node)
   )[$__range:1h]
 )`,
+    costsTotalPrior30d: `sum_over_time(
+  sum(max(node_total_hourly_cost{cluster=~"$cluster"} offset 30d) by(cluster,node))[30d:1h]
+)
+  or
+vector(0)`,
+    costsTotalCurrent30d: `sum_over_time(
+  sum(max(node_total_hourly_cost{cluster=~"$cluster"}) by(cluster,node))[30d:1h]
+)
+  or
+vector(0)`,
+    costsPerPodCurrent30d: `(
+  sum_over_time(
+    sum(max(node_total_hourly_cost{cluster=~"$cluster"}) by(cluster,node))[30d:1h]
+  )
+    or
+  vector(0)
+)
+  /
+(
+  avg_over_time(
+    sum(max(kubelet_running_pods{cluster=~"$cluster"}) by(cluster,instance))[30d:1h]
+  )
+    or
+  vector(0)
+)`,
+    costsPotentialSavings: `(
+  (
+    (
+      (
+        (
+          sum(
+            floor(
+              max(
+                max(
+                  kube_node_status_capacity{resource=~"cpu",cluster=~"$cluster"}
+                ) by(cluster,node,resource)
+              ) by(cluster,node)
+                - on(cluster,node) group_left()
+              sum(
+                max(
+                  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{
+                    container!="POD",container!="",cluster=~"$cluster"
+                  }
+                ) by(cluster,namespace,node,pod,container,resource)
+              ) by(cluster,node)
+            )
+              * on(cluster,node) group_left()
+            max(node_cpu_hourly_cost{cluster=~"$cluster"}) by(cluster,node)
+          )
+            or
+          (
+            vector(0)
+              +
+            sum(
+              (
+                (
+                  (
+                    (
+                      max(
+                        max(
+                          kube_node_status_capacity{
+                            resource=~"memory",cluster=~"$cluster"
+                          }
+                        ) by(cluster,node,resource)
+                      ) by(cluster,node)
+                        - on(cluster,node) group_left()
+                      sum(
+                        max(
+                          node_namespace_pod_container:container_memory_working_set_bytes{
+                            container!="POD",container!="",cluster=~"$cluster"
+                          }
+                        ) by(cluster,namespace,node,pod,container,resource)
+                      ) by(cluster,node)
+                    )
+                      /
+                    1024
+                  )
+                    /
+                  1024
+                )
+                  /
+                1024
+              )
+                * on(cluster,node) group_left()
+              max(node_ram_hourly_cost{cluster=~"$cluster"}) by(cluster,node)
+            )
+          )
+        )
+          or
+        (
+          vector(0)
+            +
+          sum(
+            max(node_gpu_count{cluster=~"$cluster"}) by(cluster,node)
+              - on(cluster,node) group_left()
+            (
+              sum(
+                max(
+                  container_gpu_allocation{cluster=~"$cluster"}
+                ) by(cluster,node,namespace,pod,container)
+              ) by(cluster,node)
+                * on(cluster,node) group_left()
+              max(node_gpu_hourly_cost{cluster=~"$cluster"}) by(cluster,node)
+            )
+          )
+        )
+      )
+        or
+      (
+        vector(0)
+          +
+        sum(
+          (
+            (
+              (
+                sum(
+                  pod_pvc_allocation{cluster=~"$cluster"}
+                    - on(cluster,namespace,persistentvolumeclaim) group_left()
+                  max(
+                    max(
+                      kubelet_volume_stats_used_bytes{cluster=~"$cluster"}
+                    ) without(node,instance)
+                  ) by(cluster,namespace,persistentvolumeclaim)
+                ) by(cluster,namespace,persistentvolume)
+                  /
+                1024
+              )
+                /
+              1024
+            )
+              /
+            1024
+          )
+            * on(cluster,persistentvolume) group_left()
+          max(pv_hourly_cost{cluster=~"$cluster"}) by(cluster,persistentvolume)
+        )
+      )
+    )
+      or
+    vector(0)
+  )
+    *
+  24
+)
+  *
+30`,
   },
   nodes: {
     info: `avg_over_time(
@@ -1059,7 +1205,7 @@ sum(
           resource=~"cpu"
         }
       ) by(cluster,node,resource)
-    )
+    ) by(cluster,node)
       *
     sum(
       max(
@@ -1068,7 +1214,7 @@ sum(
           node=~"$node(:[0-9]{2,5})?"
         }
       ) by(cluster,node)
-    )
+    ) by(cluster,node)
   )[$__range:1h]
 )`,
     costsMemoryAllocation: `sum_over_time(
@@ -1084,7 +1230,7 @@ sum(
                 resource=~"memory"
               }
             ) by(cluster,node,resource)
-          )
+          ) by(cluster,node)
             /
           1024
         )
@@ -1100,11 +1246,11 @@ sum(
         cluster=~"$cluster",
         node=~"$node(:[0-9]{2,5})?"
       }
-    )
+    ) by(cluster,node)
   )[$__range:1h]
 )`,
     costsCPUIdle: `sum_over_time(
-  sum(
+  sum by(cluster,node)(
     label_replace(
       sum(
         label_join(
@@ -1231,7 +1377,7 @@ sum(
   )[$__range:1h]
 )`,
     costsMemoryIdle: `sum_over_time(
-  sum(
+  sum by(cluster,node)(
     (
       (
         (
@@ -1698,12 +1844,12 @@ sum(
   )
 ) by(namespace)`,
     costsCPUAllocation: `sum_over_time(
-  sum(
+  sum by (namespace)(
     max(
       sum(
         kube_pod_container_resource_requests{
           cluster=~"$cluster",
-          namespace="$namespace",
+          namespace=~"$namespace",
           container!="POD",
           container!="",
           resource="cpu"
@@ -1715,7 +1861,7 @@ sum(
           rate(
             container_cpu_usage_seconds_total{
               cluster=~"$cluster",
-              namespace="$namespace",
+              namespace=~"$namespace",
               node!="",
               container!="POD",
               container!=""
@@ -1726,7 +1872,7 @@ sum(
             rate(
               container_cpu_usage_seconds_total{
                 cluster=~"$cluster",
-                namespace="$namespace",
+                namespace=~"$namespace",
                 node="",
                 container!="POD",
                 container!=""
@@ -1747,7 +1893,7 @@ sum(
   )[$__range:1h]
 )`,
     costsMemoryAllocation: `sum_over_time(
-  sum(
+  sum by (namespace)(
     (
       (
         (
@@ -1755,18 +1901,18 @@ sum(
             sum(
               kube_pod_container_resource_requests{
                 cluster=~"$cluster",
-                namespace="$namespace",
+                namespace=~"$namespace",
                 container!="POD",
                 container!="",
                 resource="memory"
               }
-            ) by(cluster,node,resource)
+            ) by(cluster,node,namespace,resource)
               or
             sum(
               max(
                 container_memory_working_set_bytes{
                   cluster=~"$cluster",
-                  namespace="$namespace",
+                  namespace=~"$namespace",
                   node!="",
                   container!="POD",
                   container!=""
@@ -1775,7 +1921,7 @@ sum(
                 label_replace(
                   container_memory_working_set_bytes{
                     cluster=~"$cluster",
-                    namespace="$namespace",
+                    namespace=~"$namespace",
                     node="",
                     container!="POD",
                     container!=""
@@ -1786,8 +1932,8 @@ sum(
                   "([^:]+).*"
                 )
               ) by(cluster,namespace,node,pod,container)
-            ) by(cluster,node)
-          ) by(cluster,node)
+            ) by(cluster,node,namespace)
+          ) by(cluster,node,namespace)
             /
           1024
         )
@@ -1809,7 +1955,7 @@ sum(
       sum(
         kube_pod_container_resource_requests{
           cluster=~"$cluster",
-          namespace="$namespace",
+          namespace=~"$namespace",
           container!="POD",
           container!="",
           resource="cpu"
@@ -1821,7 +1967,7 @@ sum(
           rate(
             container_cpu_usage_seconds_total{
               cluster=~"$cluster",
-              namespace="$namespace",
+              namespace=~"$namespace",
               node!="",
               container!="POD",
               container!=""
@@ -1832,7 +1978,7 @@ sum(
             rate(
               container_cpu_usage_seconds_total{
                 cluster=~"$cluster",
-                namespace="$namespace",
+                namespace=~"$namespace",
                 node="",
                 container!="POD",
                 container!=""
@@ -1861,7 +2007,7 @@ sum(
             sum(
               kube_pod_container_resource_requests{
                 cluster=~"$cluster",
-                namespace="$namespace",
+                namespace=~"$namespace",
                 container!="POD",
                 container!="",
                 resource="memory"
@@ -1872,7 +2018,7 @@ sum(
               max(
                 container_memory_working_set_bytes{
                   cluster=~"$cluster",
-                  namespace="$namespace",
+                  namespace=~"$namespace",
                   node!="",
                   container!="POD",
                   container!=""
@@ -1881,7 +2027,7 @@ sum(
                 label_replace(
                   container_memory_working_set_bytes{
                     cluster=~"$cluster",
-                    namespace="$namespace",
+                    namespace=~"$namespace",
                     node="",
                     container!="POD",
                     container!=""
@@ -3979,214 +4125,286 @@ label_join(
     ) by(cluster,namespace,pod)
   ) by(cluster,namespace,pod,workload,workload_type)
 ) by(workload,workload_type)`,
-    costsCPUAllocation: `sum_over_time(
+    costsCPUAllocation: `sum(
+  topk(
+    1,
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",
+        namespace=~"$namespace",
+        workload=~"$workload",
+        workload_type=~"$workloadtype"
+      }
+    ) by(cluster,namespace,workload,workload_type,pod)
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left()
   sum(
-    max(
-      sum(
-        max(
-          kube_pod_container_resource_requests{
-            container!="POD",
-            container!="",
-            cluster=~"$cluster",
-            namespace=~"$namespace",
-            resource=~"cpu"
-          }
-        ) by(cluster,node,namespace,pod,container,resource)
-          * on(namespace,pod) group_left()
-        namespace_workload_pod:kube_pod_owner:relabel{
-          cluster=~"$cluster",
-          namespace=~"$namespace",
-          workload=~"$workload",
-          workload_type=~"$workloadtype"
-        }
-      ) by(cluster,namespace,node,resource)
-        or
-      sum(
-        max(
-          node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
-            container!="POD",
-            container!="",
-            cluster=~"$cluster",
-            namespace=~"$namespace"
-          }
-        ) by(cluster,namespace,node,pod,container)
-          * on(namespace,pod) group_left()
-        namespace_workload_pod:kube_pod_owner:relabel{
-          cluster=~"$cluster",
-          namespace=~"$namespace",
-          workload=~"$workload",
-          workload_type=~"$workloadtype"
-        }
-      ) by(cluster,namespace,node)
-    ) by(cluster,namespace,node)
-      * on(cluster,node) group_left()
-    max(
-      node_cpu_hourly_cost{cluster=~"$cluster"}
-    ) by(cluster,node)
-  )[$__range:1h]
-)`,
-    costsMemoryAllocation: `sum_over_time(
-  sum(
-    (
+    sum_over_time(
       (
-        (
+        sum(
           max(
             sum(
-              max(
-                kube_pod_container_resource_requests{
-                  container!="POD",
-                  container!="",
-                  cluster=~"$cluster",
-                  namespace=~"$namespace",
-                  resource=~"memory"
-                }
-              ) by(cluster,node,namespace,pod,container,resource)
-                * on(namespace,pod) group_left()
-              namespace_workload_pod:kube_pod_owner:relabel{
+              kube_pod_container_resource_requests{
                 cluster=~"$cluster",
                 namespace=~"$namespace",
-                workload=~"$workload",
-                workload_type=~"$workloadtype"
+                container!="POD",
+                container!="",
+                pod=~".+",
+                resource="cpu"
               }
-            ) by(cluster,namespace,node,resource)
+            ) by(cluster,namespace,node,pod,resource)
               or
             sum(
-              max(
-                node_namespace_pod_container:container_memory_working_set_bytes{
-                  container!="POD",
-                  container!="",
-                  cluster=~"$cluster",
-                  namespace=~"$namespace"
-                }
-              ) by(cluster,node,namespace,pod,container,image)
-                * on(namespace,pod) group_left()
-              namespace_workload_pod:kube_pod_owner:relabel{
-                cluster=~"$cluster",
-                namespace=~"$namespace",
-                workload=~"$workload",
-                workload_type=~"$workloadtype"
-              }
-            ) by(cluster,namespace,node)
-          ) by(cluster,namespace,node)
-            /
-          1024
-        )
-          /
-        1024
-      )
-        /
-      1024
-    )
-      * on(cluster,node) group_left()
-    max(
-      node_ram_hourly_cost{cluster=~"$cluster"}
-    ) by(cluster,node)
-  )[$__range:1h]
-)`,
-    costsCPUIdle: `sum_over_time(
-  sum(
-    (
-      sum(
-        max(
-          kube_pod_container_resource_requests{
-            container!="POD",
-            container!="",
-            cluster=~"$cluster",
-            namespace=~"$namespace",
-            resource=~"cpu"
-          }
-        ) by(cluster,node,namespace,pod,container,resource)
-          * on(namespace,pod) group_left()
-        namespace_workload_pod:kube_pod_owner:relabel{
-          cluster=~"$cluster",
-          namespace=~"$namespace",
-          workload=~"$workload",
-          workload_type=~"$workloadtype"
-        }
-      ) by(cluster,namespace,node)
-        - on(cluster,namespace,node) group_left()
-      sum(
-        max(
-          node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{
-            container!="POD",
-            container!="",
-            cluster=~"$cluster",
-            namespace=~"$namespace"
-          }
-        ) by(cluster,namespace,node,pod,container)
-          * on(namespace,pod) group_left()
-        namespace_workload_pod:kube_pod_owner:relabel{
-          cluster=~"$cluster",
-          namespace=~"$namespace",
-          workload=~"$workload",
-          workload_type=~"$workloadtype"
-        }
-      ) by(cluster,namespace,node)
-    )
-      * on(cluster,node) group_left()
-    max(
-      node_cpu_hourly_cost{cluster=~"$cluster"}
-    ) by(cluster,node)
-  )[$__range:1h]
-)`,
-    costsMemoryIdle: `sum_over_time(
-  sum(
-    (
-      (
-        (
-          (
-            sum(
-              max(
-                kube_pod_container_resource_requests{
-                  container!="POD",
-                  container!="",
+              rate(
+                container_cpu_usage_seconds_total{
                   cluster=~"$cluster",
                   namespace=~"$namespace",
-                  resource=~"memory"
-                }
-              ) by(cluster,node,namespace,pod,container,resource)
-                * on(namespace,pod) group_left()
-              namespace_workload_pod:kube_pod_owner:relabel{
-                cluster=~"$cluster",
-                namespace=~"$namespace",
-                workload=~"$workload",
-                workload_type=~"$workloadtype"
-              }
-            ) by(cluster,namespace,node)
-              - on(cluster,namespace,node) group_left()
-            sum(
-              max(
-                node_namespace_pod_container:container_memory_working_set_bytes{
+                  node!="",
+                  pod=~".+",
                   container!="POD",
-                  container!="",
-                  cluster=~"$cluster",
-                  namespace=~"$namespace"
-                }
-              ) by(cluster,node,namespace,pod,container,image)
-                * on(namespace,pod) group_left()
-              namespace_workload_pod:kube_pod_owner:relabel{
+                  container!=""
+                }[$__rate_interval]
+              )
+                or
+              label_replace(
+                rate(
+                  container_cpu_usage_seconds_total{
+                    cluster=~"$cluster",
+                    namespace=~"$namespace",
+                    node="",
+                    pod=~".+",
+                    container!="POD",
+                    container!=""
+                  }[$__rate_interval]
+                ),
+                "node",
+                "$1",
+                "instance",
+                "([^:]+).*"
+              )
+            ) by(cluster,namespace,node,pod)
+          ) by(cluster,namespace,node,pod)
+            * on(cluster,node) group_left()
+          max(node_cpu_hourly_cost{cluster=~"$cluster"}) by(cluster,node)
+        ) by(cluster,namespace,pod)
+      )[$__range:1h]
+    )
+  ) by(cluster,namespace,pod)
+) by(cluster,namespace,workload,workload_type)`,
+    costsMemoryAllocation: `sum(
+  topk(
+    1,
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",
+        namespace=~"$namespace",
+        workload=~"$workload",
+        workload_type=~"$workloadtype"
+      }
+    ) by(cluster,namespace,workload,workload_type,pod)
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left()
+  sum(
+    sum_over_time(
+      (
+        sum(
+          (
+            (
+              (
+                max(
+                  sum(
+                    kube_pod_container_resource_requests{
+                      cluster=~"$cluster",
+                      namespace=~"$namespace",
+                      pod=~".+",
+                      container!="POD",
+                      container!="",
+                      resource="memory"
+                    }
+                  ) by(cluster,node,pod,resource)
+                    or
+                  sum(
+                    container_memory_working_set_bytes{
+                      cluster=~"$cluster",
+                      namespace=~"$namespace",
+                      node!="",
+                      pod=~".+",
+                      container!="POD",
+                      container!=""
+                    }
+                      or
+                    label_replace(
+                      container_memory_working_set_bytes{
+                        cluster=~"$cluster",
+                        namespace=~"$namespace",
+                        node="",
+                        pod=~".+",
+                        container!="POD",
+                        container!=""
+                      },
+                      "node",
+                      "$1",
+                      "instance",
+                      "([^:]+).*"
+                    )
+                  ) by(cluster,namespace,node,pod)
+                ) by(cluster,namespace,node,pod)
+                  /
+                1024
+              )
+                /
+              1024
+            )
+              /
+            1024
+          )
+            * on(cluster,node) group_left()
+          max(node_ram_hourly_cost{cluster=~"$cluster"}) by(cluster,node)
+        ) by(cluster,namespace,pod)
+      )[$__range:1h]
+    )
+  ) by(cluster,namespace,pod)
+) by(cluster,namespace,workload,workload_type)`,
+    costsCPUIdle: `sum(
+  topk(
+    1,
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",
+        namespace=~"$namespace",
+        workload=~"$workload",
+        workload_type=~"$workloadtype"
+      }
+    ) by(cluster,namespace,workload,workload_type,pod)
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left()
+  sum(
+    sum_over_time(
+      (
+        sum(
+          (
+            sum(
+              kube_pod_container_resource_requests{
                 cluster=~"$cluster",
                 namespace=~"$namespace",
-                workload=~"$workload",
-                workload_type=~"$workloadtype"
+                container!="POD",
+                container!="",
+                pod=~".+",
+                resource="cpu"
               }
-            ) by(cluster,namespace,node)
+            ) by(cluster,namespace,node,pod)
+              - on(cluster,namespace,node,pod) group_left()
+            sum(
+              rate(
+                container_cpu_usage_seconds_total{
+                  cluster=~"$cluster",
+                  namespace=~"$namespace",
+                  node!="",
+                  pod=~".+",
+                  container!="POD",
+                  container!=""
+                }[$__rate_interval]
+              )
+                or
+              label_replace(
+                rate(
+                  container_cpu_usage_seconds_total{
+                    cluster=~"$cluster",
+                    namespace=~"$namespace",
+                    node="",
+                    pod=~".+",
+                    container!="POD",
+                    container!=""
+                  }[$__rate_interval]
+                ),
+                "node",
+                "$1",
+                "instance",
+                "([^:]+).*"
+              )
+            ) by(cluster,namespace,node,pod)
           )
-            /
-          1024
-        )
-          /
-        1024
-      )
-        /
-      1024
+            * on(cluster,node) group_left()
+          max(node_cpu_hourly_cost{cluster=~"$cluster"}) by(cluster,node)
+        ) by(cluster,namespace,pod)
+      )[$__range:1h]
     )
-      * on(cluster,node) group_left()
-    max(
-      node_ram_hourly_cost{cluster=~"$cluster"}
-    ) by(cluster,node)
-  )[$__range:1h]
-)`,
+  ) by(cluster,namespace,pod)
+) by(cluster,namespace,workload,workload_type)`,
+    costsMemoryIdle: `sum(
+  topk(
+    1,
+    group(
+      namespace_workload_pod:kube_pod_owner:relabel{
+        cluster=~"$cluster",
+        namespace=~"$namespace",
+        workload=~"$workload",
+        workload_type=~"$workloadtype"
+      }
+    ) by(cluster,namespace,workload,workload_type,pod)
+  ) by(cluster,namespace,pod)
+    * on(cluster,namespace,pod) group_left()
+  sum(
+    sum_over_time(
+      (
+        sum(
+          (
+            (
+              (
+                (
+                  sum(
+                    kube_pod_container_resource_requests{
+                      cluster=~"$cluster",
+                      namespace=~"$namespace",
+                      container!="POD",
+                      container!="",
+                      pod=~".+",
+                      resource="memory"
+                    }
+                  ) by(cluster,namespace,node,pod)
+                    - on(cluster,namespace,node,pod) group_left()
+                  sum(
+                    container_memory_working_set_bytes{
+                      cluster=~"$cluster",
+                      namespace=~"$namespace",
+                      node!="",
+                      pod=~".+",
+                      container!="POD",
+                      container!=""
+                    }
+                      or
+                    label_replace(
+                      container_memory_working_set_bytes{
+                        cluster=~"$cluster",
+                        namespace=~"$namespace",
+                        node="",
+                        pod=~".+",
+                        container!="POD",
+                        container!=""
+                      },
+                      "node",
+                      "$1",
+                      "instance",
+                      "([^:]+).*"
+                    )
+                  ) by(cluster,namespace,node,pod)
+                )
+                  /
+                1024
+              )
+                /
+              1024
+            )
+              /
+            1024
+          )
+            * on(cluster,node) group_left()
+          max(node_ram_hourly_cost{cluster=~"$cluster"}) by(cluster,node)
+        ) by(cluster,namespace,pod)
+      )[$__range:1h]
+    )
+  ) by(cluster,namespace,pod)
+) by(cluster,namespace,workload,workload_type)`,
   },
   pods: {
     count: `count(kube_pod_info{cluster=~"$cluster", namespace=~"$namespace", pod!=""})`,
@@ -4937,27 +5155,28 @@ sum(
   )
 ) by(pod)`,
     costsCPUAllocation: `sum_over_time(
-  sum(
+  sum by(cluster,namespace,pod)(
     max(
       sum(
         kube_pod_container_resource_requests{
           cluster=~"$cluster",
-          namespace="$namespace",
-          pod="$pod",
+          namespace=~"$namespace",
+          pod=~"$pod",
           container=~".+",
+          node=~"$node",
           resource="cpu"
         }
-      ) by(cluster,node,pod,resource)
+      ) by(cluster,node,namespace,pod,resource)
         or
       sum(
         max(
           rate(
             container_cpu_usage_seconds_total{
               cluster=~"$cluster",
-              namespace="$namespace",
-              pod="$pod",
+              namespace=~"$namespace",
+              pod=~"$pod",
               container=~".+",
-              node!=""
+              node=~"$node",
             }[$__rate_interval]
           )
             or
@@ -4965,10 +5184,10 @@ sum(
             rate(
               container_cpu_usage_seconds_total{
                 cluster=~"$cluster",
-                namespace="$namespace",
-                pod="$pod",
+                namespace=~"$namespace",
+                pod=~"$pod",
                 container=~".+",
-                node=""
+                node=~"$node"
               }[$__rate_interval]
             ),
             "node",
@@ -4977,8 +5196,8 @@ sum(
             "([^:]+).*"
           )
         ) by(cluster,node,namespace,pod,container)
-      ) by(cluster,node,pod)
-    ) by(cluster,node,pod)
+      ) by(cluster,node,namespace,pod)
+    ) by(cluster,node,namespace,pod)
       * on(cluster,node) group_left()
     max(
       node_cpu_hourly_cost{cluster=~"$cluster"}
@@ -4986,7 +5205,7 @@ sum(
   )[$__range:1h]
 )`,
     costsMemoryAllocation: `sum_over_time(
-  sum(
+  sum by(cluster,namespace,pod)(
     (
       (
         (
@@ -4994,30 +5213,31 @@ sum(
             sum(
               kube_pod_container_resource_requests{
                 cluster=~"$cluster",
-                namespace="$namespace",
-                pod="$pod",
+                namespace=~"$namespace",
+                pod=~"$pod",
                 container=~".+",
+                node=~"$node",
                 resource="memory"
               }
-            ) by(cluster,node,pod,resource)
+            ) by(cluster,node,namespace,pod,resource)
               or
             sum(
               max(
                 container_memory_working_set_bytes{
                   cluster=~"$cluster",
-                  namespace="$namespace",
-                  pod="$pod",
+                  namespace=~"$namespace",
+                  pod=~"$pod",
                   container=~".+",
-                  node!=""
+                  node=~"$node"
                 }
                   or
                 label_replace(
                   container_memory_working_set_bytes{
                     cluster=~"$cluster",
-                    namespace="$namespace",
-                    pod="$pod",
+                    namespace=~"$namespace",
+                    pod=~"$pod",
                     container=~".+",
-                    node=""
+                    node=~"$node"
                   },
                   "node",
                   "$1",
@@ -5025,8 +5245,8 @@ sum(
                   "([^:]+).*"
                 )
               ) by(cluster,node,namespace,pod,container)
-            ) by(cluster,node,pod)
-          ) by(cluster,node,pod)
+            ) by(cluster,node,namespace,pod)
+          ) by(cluster,node,namespace,pod)
             /
           1024
         )
@@ -5043,7 +5263,7 @@ sum(
   )[$__range:1h]
 )`,
     costsCPUIdle: `sum_over_time(
-  sum(
+  sum by(cluster,namespace,pod)(
     (
       (
         (
@@ -5051,22 +5271,23 @@ sum(
             sum(
               kube_pod_container_resource_requests{
                 cluster=~"$cluster",
-                namespace="$namespace",
-                pod="$pod",
+                namespace=~"$namespace",
+                pod=~"$pod",
                 container=~".+",
+                node=~"$node",
                 resource="memory"
               }
-            ) by(cluster,pod)
-              - on(cluster,pod) group_left(node)
+            ) by(cluster,namespace,pod)
+              - on(cluster,namespace,pod) group_left(node)
             sum(
               max(
                 rate(
                   container_cpu_usage_seconds_total{
                     cluster=~"$cluster",
-                    namespace="$namespace",
-                    pod="$pod",
+                    namespace=~"$namespace",
+                    pod=~"$pod",
                     container=~".+",
-                    node!=""
+                    node=~"$node"
                   }[$__rate_interval]
                 )
                   or
@@ -5074,10 +5295,10 @@ sum(
                   rate(
                     container_cpu_usage_seconds_total{
                       cluster=~"$cluster",
-                      namespace="$namespace",
-                      pod="$pod",
+                      namespace=~"$namespace",
+                      pod=~"$pod",
                       container=~".+",
-                      node=""
+                      node=~"$node"
                     }[$__rate_interval]
                   ),
                   "node",
@@ -5086,7 +5307,7 @@ sum(
                   "([^:]+).*"
                 )
               ) by(cluster,node,namespace,pod,container)
-            ) by(cluster,node,pod)
+            ) by(cluster,node,namespace,pod)
           )
             /
           1024
@@ -5102,7 +5323,7 @@ sum(
   )[$__range:1h]
 )`,
     costsMemoryIdle: `sum_over_time(
-  sum(
+  sum by(cluster,namespace,pod)(
     (
       (
         (
@@ -5110,30 +5331,31 @@ sum(
             sum(
               kube_pod_container_resource_requests{
                 cluster=~"$cluster",
-                namespace="$namespace",
-                pod="$pod",
+                namespace=~"$namespace",
+                pod=~"$pod",
                 container=~".+",
+                node=~"$node",
                 resource="memory"
               }
-            ) by(cluster,pod)
-              - on(cluster,pod) group_left(node)
+            ) by(cluster,namespace,pod)
+              - on(cluster,namespace,pod) group_left(node)
             sum(
               max(
                 container_memory_working_set_bytes{
                   cluster=~"$cluster",
-                  namespace="$namespace",
-                  pod="$pod",
+                  namespace=~"$namespace",
+                  pod=~"$pod",
                   container=~".+",
-                  node!=""
+                  node=~"$node"
                 }
                   or
                 label_replace(
                   container_memory_working_set_bytes{
                     cluster=~"$cluster",
-                    namespace="$namespace",
-                    pod="$pod",
+                    namespace=~"$namespace",
+                    pod=~"$pod",
                     container=~".+",
-                    node=""
+                    node=~"$node"
                   },
                   "node",
                   "$1",
@@ -5141,7 +5363,7 @@ sum(
                   "([^:]+).*"
                 )
               ) by(cluster,node,namespace,pod,container)
-            ) by(cluster,node,pod)
+            ) by(cluster,node,namespace,pod)
           )
             /
           1024

--- a/src/components/metrics/shared/RowCosts.tsx
+++ b/src/components/metrics/shared/RowCosts.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { useStyles2 } from '@grafana/ui';
-import { VizConfigBuilders } from '@grafana/scenes';
-import { useQueryRunner, VizPanel } from '@grafana/scenes-react';
-import { FieldColorModeId, MappingType } from '@grafana/schema';
 
 import { getStyles } from '../../../utils/utils.styles';
-import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+import { StatCosts } from './StatCosts';
 
 interface Props {
   costsCPUAllocation: string;
@@ -24,25 +21,25 @@ export function RowCosts({
 
   return (
     <div className={styles.dashboard.row.height100px}>
-      <SingleStat
+      <StatCosts
         title="CPU Allocation Costs"
         description="Allocation is the greater amount of either the actual CPU usage or the requested amount. The sum of the CPU allocation in each hour is multiplied by the hourly CPU cost, which is estimated by OpenCost."
         refId="cpu"
         expr={costsCPUAllocation}
       />
-      <SingleStat
+      <StatCosts
         title="Memory Allocation Costs"
         description="Allocation is the greater amount of either the actual memory usage or the requested amount. The sum of the memory allocation in each hour is multiplied by the hourly memory cost, which is estimated by OpenCost."
         refId="memory"
         expr={costsMemoryAllocation}
       />
-      <SingleStat
+      <StatCosts
         title="Total Allocation Costs"
         description="Allocation is the greater amount of either the actual CPU and memory usage or the requested amount. The sum of the CPU and memory allocation in each hour is multiplied by the hourly CPU and memory cost, which is estimated by OpenCost."
         refId="total"
         expr={`(${costsCPUAllocation}) + (${costsMemoryAllocation})`}
       />
-      <SingleStat
+      <StatCosts
         title="CPU Idle Costs"
         description={`For Nodes and Clusters, idle cost is the difference between usage and physical capacity. For resources not at the Node or Cluster level, idle cost is the difference between usage and requests. Requests act as reserved resources, so unused requests can't be used by other objects in Kubernetes.
 
@@ -50,7 +47,7 @@ export function RowCosts({
         refId="cpu"
         expr={costsCPUIdle}
       />
-      <SingleStat
+      <StatCosts
         title="Memory Idle Costs"
         description={`For Nodes and Clusters, idle cost is the difference between usage and physical capacity. For resources not at the Node or Cluster level, idle cost is the difference between usage and requests. Requests act as reserved resources, so unused requests can't be used by other objects in Kubernetes.
 
@@ -58,7 +55,7 @@ export function RowCosts({
         refId="memory"
         expr={costsMemoryIdle}
       />
-      <SingleStat
+      <StatCosts
         title="Total Idle Costs"
         description={`For Nodes and Clusters, idle cost is the difference between usage and physical capacity. For resources not at the Node or Cluster level, idle cost is the difference between usage and requests. Requests act as reserved resources, so unused requests can't be used by other objects in Kubernetes.
 
@@ -67,69 +64,5 @@ export function RowCosts({
         expr={`(${costsCPUIdle}) + (${costsMemoryIdle})`}
       />
     </div>
-  );
-}
-
-function SingleStat({
-  title,
-  description,
-  refId,
-  expr,
-}: {
-  title: string;
-  description: string;
-  refId: string;
-  expr: string;
-}) {
-  const dataProvider = useQueryRunner({
-    datasource: {
-      type: 'prometheus',
-      uid: '$prometheus',
-    },
-    queries: [
-      {
-        refId: refId,
-        format: 'time_series',
-        instant: true,
-        expr: expr,
-      },
-    ],
-  });
-
-  const viz = VizConfigBuilders.stat()
-    .setUnit('currencyUSD')
-    .setColor({
-      mode: FieldColorModeId.Fixed,
-      fixedColor: 'text',
-    })
-    .setMappings([
-      {
-        options: {
-          from: null,
-          to: 0,
-          result: {
-            text: 'Undersized',
-            index: 0,
-          },
-        },
-        type: MappingType.RangeToText,
-      },
-    ])
-
-    .build();
-
-  const menu = useVizPanelMenu({
-    data: dataProvider.useState(),
-    viz,
-  });
-
-  return (
-    <VizPanel
-      title={title}
-      description={description}
-      menu={menu}
-      viz={viz}
-      dataProvider={dataProvider}
-    />
   );
 }

--- a/src/components/metrics/shared/StatCosts.tsx
+++ b/src/components/metrics/shared/StatCosts.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { VizConfigBuilders } from '@grafana/scenes';
+import { useQueryRunner, VizPanel } from '@grafana/scenes-react';
+import { FieldColorModeId, MappingType } from '@grafana/schema';
+
+import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+
+interface Props {
+  title: string;
+  description: string;
+  refId: string;
+  expr: string;
+}
+
+export function StatCosts({ title, description, refId, expr }: Props) {
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: [
+      {
+        refId: refId,
+        format: 'time_series',
+        instant: true,
+        expr: expr,
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.stat()
+    .setUnit('currencyUSD')
+    .setColor({
+      mode: FieldColorModeId.Fixed,
+      fixedColor: 'text',
+    })
+    .setMappings([
+      {
+        options: {
+          from: null,
+          to: 0,
+          result: {
+            text: 'Undersized',
+            index: 0,
+          },
+        },
+        type: MappingType.RangeToText,
+      },
+    ])
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title={title}
+      description={description}
+      menu={menu}
+      viz={viz}
+      dataProvider={dataProvider}
+    />
+  );
+}

--- a/src/components/metrics/shared/TableCosts.tsx
+++ b/src/components/metrics/shared/TableCosts.tsx
@@ -1,0 +1,315 @@
+import React from 'react';
+import { DataTransformerID, MappingType } from '@grafana/data';
+import {
+  useDataTransformer,
+  useQueryRunner,
+  VizPanel,
+} from '@grafana/scenes-react';
+import { SceneDataQuery, VizConfigBuilders } from '@grafana/scenes';
+
+import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+import { ROUTES } from '../../../constants';
+import { prefixRoute } from '../../../utils/utils.routing';
+
+interface Props {
+  title: string;
+  cpuAllocationExpr: string;
+  memoryAllocationExpr: string;
+  cpuIdleExpr: string;
+  memoryIdleExpr: string;
+}
+
+export function TableCosts({
+  title,
+  cpuAllocationExpr,
+  memoryAllocationExpr,
+  cpuIdleExpr,
+  memoryIdleExpr,
+}: Props) {
+  const queries: SceneDataQuery[] = [
+    {
+      refId: 'cpu_allocation',
+      format: 'table',
+      instant: true,
+      expr: cpuAllocationExpr,
+    },
+    {
+      refId: 'cpu_idle',
+      format: 'table',
+      instant: true,
+      expr: cpuIdleExpr,
+    },
+    {
+      refId: 'memory_allocation',
+      format: 'table',
+      instant: true,
+      expr: memoryAllocationExpr,
+    },
+    {
+      refId: 'memory_idle',
+      format: 'table',
+      instant: true,
+      expr: memoryIdleExpr,
+    },
+  ];
+
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: queries,
+  });
+
+  const dataTransformer = useDataTransformer({
+    data: dataProvider,
+    transformations: [
+      {
+        id: DataTransformerID.merge,
+        options: {},
+      },
+      {
+        id: DataTransformerID.calculateField,
+        options: {
+          mode: 'binary',
+          reduce: {
+            reducer: 'sum',
+          },
+          alias: '',
+          binary: {
+            left: 'Value #cpu_allocation',
+            operator: '+',
+            right: 'Value #memory_allocation',
+          },
+        },
+      },
+      {
+        id: DataTransformerID.calculateField,
+        options: {
+          mode: 'binary',
+          reduce: {
+            reducer: 'sum',
+          },
+          alias: '',
+          binary: {
+            left: 'Value #cpu_idle',
+            operator: '+',
+            right: 'Value #memory_idle',
+          },
+        },
+      },
+      {
+        id: DataTransformerID.organize,
+        options: {
+          includeByName: {
+            ['node']: true,
+            ['namespace']: true,
+            ['workload']: true,
+            ['workload_type']: true,
+            ['pod']: true,
+            ['container']: true,
+            ['Value #cpu_allocation']: true,
+            ['Value #memory_allocation']: true,
+            ['Value #cpu_allocation + Value #memory_allocation']: true,
+            ['Value #cpu_idle']: true,
+            ['Value #memory_idle']: true,
+            ['Value #cpu_idle + Value #memory_idle']: true,
+          },
+          indexByName: {
+            ['namespace']: 0,
+            ['pod']: 1,
+            ['container']: 2,
+            ['node']: 3,
+            ['workload']: 4,
+            ['workload_type']: 5,
+            ['Value #cpu_allocation']: 7,
+            ['Value #memory_allocation']: 8,
+            ['Value #cpu_allocation + Value #memory_allocation']: 9,
+            ['Value #cpu_idle']: 10,
+            ['Value #memory_idle']: 11,
+            ['Value #cpu_idle + Value #memory_idle']: 12,
+          },
+          renameByName: {
+            ['node']: 'NODE',
+            ['namespace']: 'NAMESPACE',
+            ['workload']: 'WORKLOAD',
+            ['workload_type']: 'WORKLOAD TYPE',
+            ['pod']: 'POD',
+            ['container']: 'CONTAINER',
+            ['phase']: 'PHASE',
+            ['image_spec']: 'IMAGE',
+            ['Value #cpu_allocation']: 'CPU ALLOCATION',
+            ['Value #memory_allocation']: 'MEMORY ALLOCATION',
+            ['Value #cpu_idle']: 'CPU IDLE',
+            ['Value #memory_idle']: 'MEMORY IDLE',
+            ['Value #cpu_allocation + Value #memory_allocation']:
+              'TOTAL ALLOCATION',
+            ['Value #cpu_idle + Value #memory_idle']: 'TOTAL IDLE',
+          },
+        },
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.table()
+    .setOption('sortBy', [
+      {
+        desc: false,
+        displayName: 'NAMESPACE',
+      },
+      {
+        desc: false,
+        displayName: 'POD',
+      },
+      {
+        desc: false,
+        displayName: 'NODE',
+      },
+      {
+        desc: false,
+        displayName: 'WORKLOAD',
+      },
+      {
+        desc: false,
+        displayName: 'WORKLOAD TYPE',
+      },
+    ])
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('node')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsNodes)}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('namespace')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsNamespaces)}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod,var-pvc}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('workload')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsWorkloads)}/\${__data.fields["namespace"].text}/\${__data.fields["workload_type"].text}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod,var-pvc}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('workload_type')
+        .overrideCustomFieldConfig('width', 150)
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('pod')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsPods)}/\${__data.fields["namespace"].text}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod,var-pvc}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) =>
+      b
+        .matchFieldsWithName('Value #cpu_allocation')
+        .overrideUnit('currencyUSD'),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsWithName('Value #memory_allocation')
+        .overrideUnit('currencyUSD'),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsWithName('Value #cpu_allocation + Value #memory_allocation')
+        .overrideUnit('currencyUSD'),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsWithName('Value #cpu_idle')
+        .overrideUnit('currencyUSD')
+        .overrideMappings([
+          {
+            options: {
+              from: null,
+              to: 0,
+              result: {
+                text: 'Undersized',
+                index: 0,
+              },
+            },
+            type: MappingType.RangeToText,
+          },
+        ]),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsWithName('Value #memory_idle')
+        .overrideUnit('currencyUSD')
+        .overrideMappings([
+          {
+            options: {
+              from: null,
+              to: 0,
+              result: {
+                text: 'Undersized',
+                index: 0,
+              },
+            },
+            type: MappingType.RangeToText,
+          },
+        ]),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsWithName('Value #cpu_idle + Value #memory_idle')
+        .overrideUnit('currencyUSD')
+        .overrideMappings([
+          {
+            options: {
+              from: null,
+              to: 0,
+              result: {
+                text: 'Undersized',
+                index: 0,
+              },
+            },
+            type: MappingType.RangeToText,
+          },
+        ]),
+    )
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title={title}
+      menu={menu}
+      viz={viz}
+      dataProvider={dataTransformer}
+    />
+  );
+}

--- a/src/components/metrics/shared/TableCostsTop.tsx
+++ b/src/components/metrics/shared/TableCostsTop.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { DataTransformerID } from '@grafana/data';
+import {
+  useDataTransformer,
+  useQueryRunner,
+  VizPanel,
+} from '@grafana/scenes-react';
+import { SceneDataQuery, VizConfigBuilders } from '@grafana/scenes';
+
+import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
+import { ROUTES } from '../../../constants';
+import { prefixRoute } from '../../../utils/utils.routing';
+
+interface Props {
+  title: string;
+  cpuAllocationExpr: string;
+  memoryAllocationExpr: string;
+}
+
+export function TableCostsTop({
+  title,
+  cpuAllocationExpr,
+  memoryAllocationExpr,
+}: Props) {
+  const queries: SceneDataQuery[] = [
+    {
+      refId: 'cpu_allocation',
+      format: 'table',
+      instant: true,
+      expr: cpuAllocationExpr,
+    },
+    {
+      refId: 'memory_allocation',
+      format: 'table',
+      instant: true,
+      expr: memoryAllocationExpr,
+    },
+  ];
+
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: queries,
+  });
+
+  const dataTransformer = useDataTransformer({
+    data: dataProvider,
+    transformations: [
+      {
+        id: DataTransformerID.merge,
+        options: {},
+      },
+      {
+        id: DataTransformerID.calculateField,
+        options: {
+          mode: 'binary',
+          reduce: {
+            reducer: 'sum',
+          },
+          alias: '',
+          binary: {
+            left: 'Value #cpu_allocation',
+            operator: '+',
+            right: 'Value #memory_allocation',
+          },
+        },
+      },
+      {
+        id: DataTransformerID.organize,
+        options: {
+          includeByName: {
+            ['namespace']: true,
+            ['workload']: true,
+            ['Value #cpu_allocation + Value #memory_allocation']: true,
+          },
+          indexByName: {
+            ['namespace']: 0,
+            ['workload']: 1,
+            ['Value #cpu_allocation + Value #memory_allocation']: 2,
+          },
+          renameByName: {
+            ['namespace']: 'NAMESPACE',
+            ['workload']: 'WORKLOAD',
+            ['Value #cpu_allocation + Value #memory_allocation']: 'COST',
+          },
+        },
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.table()
+    .setOption('sortBy', [
+      {
+        desc: true,
+        displayName: 'COST',
+      },
+    ])
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('namespace')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsNamespaces)}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod,var-pvc}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('workload')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsWorkloads)}/\${__data.fields["namespace"].text}/\${__data.fields["workload_type"].text}/\${__value.raw}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod,var-pvc}`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) =>
+      b
+        .matchFieldsWithName('Value #cpu_allocation + Value #memory_allocation')
+        .overrideUnit('currencyUSD'),
+    )
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title={title}
+      menu={menu}
+      viz={viz}
+      dataProvider={dataTransformer}
+    />
+  );
+}

--- a/src/components/metrics/workloads/WorkloadPageOverview.tsx
+++ b/src/components/metrics/workloads/WorkloadPageOverview.tsx
@@ -28,6 +28,7 @@ import datasourcePluginJson from '../../../datasource/plugin.json';
 import { useVizPanelMenu } from '../../../hooks/useVizPanelMenu';
 import { TimeSeriesWorkloadStatus } from '../shared/TimeSeriesWorkloadStatus';
 import { RowCosts } from '../shared/RowCosts';
+import { TableCosts } from '../shared/TableCosts';
 
 interface Props {
   workloadType: string;
@@ -268,6 +269,7 @@ function Pods() {
           <RadioButtonGroup
             options={[
               { label: 'Usage', value: 'usage' },
+              { label: 'Cost', value: 'cost' },
               { label: 'Info', value: 'info' },
             ]}
             value={selected}
@@ -295,6 +297,15 @@ function Pods() {
                 queries.pods.memoryUsageMaxPercentOverTime
               }
               alertsExpr={queries.pods.alertsCount}
+            />
+          )}
+          {selected === 'cost' && (
+            <TableCosts
+              title="Pods"
+              cpuAllocationExpr={queries.pods.costsCPUAllocation}
+              memoryAllocationExpr={queries.pods.costsMemoryAllocation}
+              cpuIdleExpr={queries.pods.costsCPUIdle}
+              memoryIdleExpr={queries.pods.costsMemoryIdle}
             />
           )}
           {selected === 'info' && <TableKubernetesPods />}


### PR DESCRIPTION
This commit extends the integration of the OpenCost metrics into the
plugin. We now also display the cost metrics next to the usage and info
tables on the bottom of the overview pages for nodes, namespaces and
workloads. Additionally, we added a new cost tab to the metrics page,
which shows the costs for the last 30 days, the costs per pod, the
potential savings, when the workloads are optimized and a table with the
top namespaces and workloads by cost.
