### PR TITLE
Use Custom Variable for Namespaces on Home and Metrics Page

### DIFF
--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Card, LinkButton, Stack, useStyles2 } from '@grafana/ui';
 import {
@@ -9,6 +9,7 @@ import {
   VariableControl,
   TimeRangePicker,
   RefreshPicker,
+  CustomVariable,
 } from '@grafana/scenes-react';
 
 import { ROUTES } from '../../constants';
@@ -21,7 +22,7 @@ import { getStyles } from '../../utils/utils.styles';
 import datasourcePluginJson from '../../datasource/plugin.json';
 import { StatWithFixedColorAndLink } from '../metrics/shared/StatWithFixedColorAndLink';
 import { TimeSeriesMemoryOrCPU } from '../metrics/shared/TimeSeriesMemoryOrCPU';
-import { queries, variableQuery } from '../metrics/queries';
+import { queries } from '../metrics/queries';
 
 interface Item {
   route: ROUTES;
@@ -109,23 +110,12 @@ export function HomePage() {
             refresh={VariableRefresh.onDashboardLoad}
             hide={VariableHide.hideVariable}
           >
-            <QueryVariable
+            <CustomVariable
               name="namespace"
               label="Namespace"
-              datasource={{
-                type: 'prometheus',
-                uid: '$prometheus',
-              }}
-              query={{
-                refId: 'namespaces',
-                query: variableQuery(queries.namespaces.labelsByCluster),
-              }}
-              refresh={VariableRefresh.onTimeRangeChanged}
-              isMulti={true}
-              includeAll={true}
-              initialValue={'$__all'}
-              allValue=".+"
-              sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+              query=".+"
+              initialValue=".+"
+              hide={VariableHide.hideVariable}
             >
               <PluginPage
                 actions={
@@ -229,7 +219,7 @@ export function HomePage() {
                   </ul>
                 </div>
               </PluginPage>
-            </QueryVariable>
+            </CustomVariable>
           </QueryVariable>
         </QueryVariable>
       </DataSourceVariable>

--- a/src/components/metrics/metrics/MetricsPage.tsx
+++ b/src/components/metrics/metrics/MetricsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { VariableHide, VariableRefresh, VariableSort } from '@grafana/data';
+import { VariableHide, VariableRefresh } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import {
@@ -15,7 +15,6 @@ import pluginJson from '../../../plugin.json';
 import resourcesImg from '../../../img/logo.svg';
 import { getStyles } from '../../../utils/utils.styles';
 import datasourcePluginJson from '../../../datasource/plugin.json';
-import { queries, variableQuery } from '../queries';
 import { MetricsPageOverview } from './MetricsPageOverview';
 import { MetricsPageCost } from './MetricsPageCost';
 
@@ -67,23 +66,12 @@ export function MetricsPage() {
               initialValue=".+"
               hide={VariableHide.hideVariable}
             >
-              <QueryVariable
+              <CustomVariable
                 name="namespace"
                 label="Namespace"
-                datasource={{
-                  type: 'prometheus',
-                  uid: '$prometheus',
-                }}
-                query={{
-                  refId: 'namespaces',
-                  query: variableQuery(queries.namespaces.labelsByCluster),
-                }}
-                refresh={VariableRefresh.onTimeRangeChanged}
-                isMulti={true}
-                includeAll={true}
-                initialValue={'$__all'}
-                allValue=".+"
-                sort={VariableSort.alphabeticalCaseInsensitiveAsc}
+                query=".+"
+                initialValue=".+"
+                hide={VariableHide.hideVariable}
               >
                 <CustomVariable
                   name="workloadtype"
@@ -142,7 +130,7 @@ export function MetricsPage() {
                     </PluginPage>
                   </CustomVariable>
                 </CustomVariable>
-              </QueryVariable>
+              </CustomVariable>
             </CustomVariable>
           </QueryVariable>
         </QueryVariable>

--- a/src/components/metrics/shared/StatWithFixedColorAndLink.tsx
+++ b/src/components/metrics/shared/StatWithFixedColorAndLink.tsx
@@ -49,7 +49,7 @@ export function StatWithFixedColorAndLink({
     .setOption('textMode', BigValueTextMode.Value)
     .setLinks([
       {
-        url: `${prefixRoute(route)}\${__url.params}`,
+        url: `${prefixRoute(route)}\${__url.params:exclude:var-node,var-namespace,var-workloadtype,var-workload,var-pod,var-pvc}`,
         title: title,
       },
     ])


### PR DESCRIPTION
Use a custom variable instead of a query variable for the namespaces
variable on the home and metrics page. The value for this variable is
always `.+`, which matches all namespaces.

This was done, because the namespaces variable is not used in all panels
on these pages, making it difficult for users to understand what gets
filtered when they change the value of the namespaces variable.
