### PR TITLE
feat(helm): show manifests in helm details page

### DIFF
--- a/src/datasource/components/helm/Details.tsx
+++ b/src/datasource/components/helm/Details.tsx
@@ -12,6 +12,7 @@ import { Yaml } from '../shared/details/Yaml';
 import { Templates } from './Templates';
 import { AI } from './AI';
 import pluginJson from '../../plugin.json';
+import { Manifests } from './Manifests';
 
 await initPluginTranslations(pluginJson.id, [loadResources]);
 
@@ -108,6 +109,14 @@ export function Details({
                 setActiveTab('templates');
               }}
             />
+            <Tab
+              label="Manifests"
+              active={activeTab === 'manifests'}
+              onChangeTab={(ev) => {
+                ev?.preventDefault();
+                setActiveTab('manifests');
+              }}
+            />
             {ai.value && (
               <Tab
                 label="AI"
@@ -130,7 +139,13 @@ export function Details({
         </Alert>
       ) : (
         <>
-          {activeTab === 'overview' && <Overview release={state.value} />}
+          {activeTab === 'overview' && (
+            <Overview
+              datasource={datasource}
+              namespace={namespace}
+              release={state.value}
+            />
+          )}
           {activeTab === 'history' && (
             <History
               datasource={datasource}
@@ -143,6 +158,9 @@ export function Details({
             <Yaml value={state.value?.chart?.values} />
           )}
           {activeTab === 'templates' && <Templates release={state.value} />}
+          {activeTab === 'manifests' && (
+            <Manifests namespace={namespace} release={state.value} />
+          )}
           {activeTab === 'ai' && (
             <AI
               datasource={datasource}

--- a/src/datasource/components/helm/Manifests.tsx
+++ b/src/datasource/components/helm/Manifests.tsx
@@ -1,0 +1,94 @@
+import React, { useMemo, useState } from 'react';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import {
+  CodeEditor,
+  Combobox,
+  ComboboxOption,
+  Stack,
+  useStyles2,
+} from '@grafana/ui';
+import YAML from 'yaml';
+import { css } from '@emotion/css';
+
+import { Release } from '../../types/helm';
+import { KubernetesManifest } from '../../types/kubernetes';
+
+interface Props {
+  namespace?: string;
+  release: Release | undefined;
+}
+
+export function Manifests({ namespace, release }: Props) {
+  const styles = useStyles2(() => {
+    return {
+      editorWrapper: css({
+        flex: 1,
+      }),
+      editorContainer: css({
+        width: 'fit-content',
+        border: 'none',
+      }),
+    };
+  });
+
+  const [selectedTemplate, setSelectedTemplate] = useState(0);
+  const { manifests } = useMemo(() => {
+    const parsedManifests: KubernetesManifest[] = [];
+
+    try {
+      if (release?.manifest) {
+        const documents = YAML.parseAllDocuments(release?.manifest);
+        for (const document of documents) {
+          const jsonDocument = document.toJSON() as KubernetesManifest;
+          parsedManifests.push(jsonDocument);
+        }
+      }
+    } catch (_) { }
+
+    return { manifests: parsedManifests };
+  }, [release?.manifest]);
+
+  return (
+    <Stack
+      direction="column"
+      gap={2}
+      justifyContent="space-between"
+      height="100%"
+    >
+      <div></div>
+      <div>
+        <Combobox<number>
+          value={selectedTemplate}
+          options={manifests.map((manifest, index) => {
+            return {
+              label: `${manifest.metadata?.namespace || namespace}/${manifest.metadata?.name} (${manifest.kind})`,
+              value: index,
+            };
+          })}
+          onChange={(option: ComboboxOption<number>) =>
+            setSelectedTemplate(option.value)
+          }
+        />
+      </div>
+
+      <div className={styles.editorWrapper}>
+        <AutoSizer>
+          {({ width, height }) => {
+            return (
+              <CodeEditor
+                containerStyles={styles.editorContainer}
+                width={width}
+                height={height}
+                language="yaml"
+                showLineNumbers={true}
+                showMiniMap={true}
+                readOnly={true}
+                value={YAML.stringify(manifests[selectedTemplate])}
+              />
+            );
+          }}
+        </AutoSizer>
+      </div>
+    </Stack>
+  );
+}

--- a/src/datasource/components/helm/Overview.tsx
+++ b/src/datasource/components/helm/Overview.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+import YAML from 'yaml';
+import { Badge, ScrollContainer, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 
 import { Release } from '../../types/helm';
 import {
@@ -7,13 +10,46 @@ import {
   DefinitionLists,
 } from '../shared/definitionlist/DefinitionList';
 import { formatTimeString } from '../../../utils/utils.time';
-import { ScrollContainer } from '@grafana/ui';
+import { KubernetesManifest } from '../../types/kubernetes';
+import { getResourceId } from '../../../utils/utils.resource';
+import { Resources } from '../shared/details/Resources';
 
 interface Props {
+  datasource?: string;
+  namespace?: string;
   release: Release | undefined;
 }
 
-export function Overview({ release }: Props) {
+export function Overview({ datasource, namespace, release }: Props) {
+  const styles = useStyles2(() => {
+    return {
+      badge: css({
+        cursor: 'pointer',
+      }),
+    };
+  });
+
+  const [selectedResource, setSelectedResource] = useState<
+    | { kind: string; resourceId: string; namespace?: string; name: string }
+    | undefined
+  >(undefined);
+
+  const { manifests } = useMemo(() => {
+    const parsedManifests: KubernetesManifest[] = [];
+
+    try {
+      if (release?.manifest) {
+        const documents = YAML.parseAllDocuments(release?.manifest);
+        for (const document of documents) {
+          const jsonDocument = document.toJSON() as KubernetesManifest;
+          parsedManifests.push(jsonDocument);
+        }
+      }
+    } catch (_) { }
+
+    return { manifests: parsedManifests };
+  }, [release?.manifest]);
+
   return (
     <ScrollContainer height="100%">
       <DefinitionLists>
@@ -44,8 +80,43 @@ export function Overview({ release }: Props) {
           <DefinitionItem label="Notes">
             {release?.info?.notes || '-'}
           </DefinitionItem>
+          <DefinitionItem label="Manifests">
+            {manifests.map((manifest) => {
+              return (
+                <Badge
+                  className={styles.badge}
+                  key={`${manifest.kind}-${manifest.metadata?.name}`}
+                  color="blue"
+                  onClick={() =>
+                    setSelectedResource({
+                      kind: manifest.kind || '',
+                      resourceId: getResourceId(
+                        manifest.kind || '',
+                        manifest.apiVersion || '',
+                      ),
+                      namespace: manifest.metadata?.namespace || namespace,
+                      name: manifest.metadata?.name || '',
+                    })
+                  }
+                  text={`${manifest.metadata?.namespace || namespace}/${manifest.metadata?.name} (${manifest.kind})`}
+                />
+              );
+            })}
+          </DefinitionItem>
         </DefinitionList>
       </DefinitionLists>
+
+      {selectedResource && (
+        <Resources
+          title={selectedResource.kind}
+          datasource={datasource}
+          resourceId={selectedResource.resourceId}
+          namespace={selectedResource.namespace || '*'}
+          parameterName="fieldSelector"
+          parameterValue={`metadata.name=${selectedResource.name}`}
+          onClose={() => setSelectedResource(undefined)}
+        />
+      )}
     </ScrollContainer>
   );
 }


### PR DESCRIPTION
The details page of a helm release now has a new tab called "Manifests"
that shows the rendered manifests of the helm release. This allows users
to easily view the manifests. The "Overview" tab now also shows the
manifests as badges, which can be clicked by a user to directly view the
associated Kubernetes resource.
