### PR TITLE
feat: add search

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -16,15 +16,17 @@ import { PersistentVolumeClaimPage } from './persistentcolumeclaims/PersistentVo
 import { PersistentVolumeClaimsPage } from './persistentcolumeclaims/PersistentVolumeClaimsPage';
 import { PodPage } from './pods/PodPage';
 import { PodsPage } from './pods/PodsPage';
+import { ResourcesPage } from './resources/ResourcesPage';
+import { SearchPage } from './search/SearchPage';
 import { WorkloadPage } from './workloads/WorkloadPage';
 import { WorkloadsPage } from './workloads/WorkloadsPage';
-import { ResourcesPage } from './resources/ResourcesPage';
 
 function App(props: AppRootProps) {
   return (
     <PluginPropsContext.Provider value={props}>
       <Routes>
         <Route path={ROUTES.Home} element={<HomePage />} />
+        <Route path={ROUTES.Search} element={<SearchPage />} />
         <Route path={ROUTES.MetricsNodes} element={<NodesPage />} />
         <Route path={`${ROUTES.MetricsNodes}/:node`} element={<NodePage />} />
         <Route path={ROUTES.MetricsNamespaces} element={<NamespacesPage />} />

--- a/src/components/home/HomePageOverview.tsx
+++ b/src/components/home/HomePageOverview.tsx
@@ -19,6 +19,7 @@ import { StatWithFixedColorAndLink } from '../shared/StatWithFixedColorAndLink';
 import { TableCosts } from '../shared/TableCosts';
 import { TableResourceUsage } from '../shared/TableResourceUsage';
 import { TimeSeriesMemoryOrCPU } from '../shared/TimeSeriesMemoryOrCPU';
+import { HomePageOverviewSearch } from './HomePageOverviewSearch';
 
 export function HomePageOverview() {
   const styles = useStyles2(getStyles);
@@ -28,6 +29,7 @@ export function HomePageOverview() {
       <div className={styles.dashboard.header.container}>
         <VariableControl name="datasource" />
         <div className={styles.dashboard.header.spacer} />
+        <HomePageOverviewSearch />
         <LinkButton
           href={prefixRoute(ROUTES.Kubeconfig)}
           size="md"

--- a/src/components/home/HomePageOverviewSearch.tsx
+++ b/src/components/home/HomePageOverviewSearch.tsx
@@ -1,0 +1,37 @@
+import { useVariables } from '@grafana/scenes-react';
+import { Input } from '@grafana/ui';
+import React, { ChangeEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { ROUTES } from '../../constants';
+import { prefixRoute } from '../../utils/utils.routing';
+
+export function HomePageOverviewSearch() {
+  const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const variables = useVariables();
+  const datasource = variables.find((v) => v.state.name === 'datasource');
+  const datasourceValue = datasource?.getValue();
+
+  return (
+    <div>
+      <Input
+        placeholder="Search..."
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+          setSearchTerm(event.target.value);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            navigate(
+              prefixRoute(ROUTES.Search) +
+              `?var-datasource=${datasourceValue}&var-searchterm=.*${searchTerm}.*`,
+            );
+          }
+        }}
+        value={searchTerm}
+        width={25}
+      />
+    </div>
+  );
+}

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -1,0 +1,118 @@
+import { VariableHide, VariableRefresh } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
+import {
+  CustomVariable,
+  DataSourceVariable,
+  QueryVariable,
+  RefreshPicker,
+  SceneContextProvider,
+  TimeRangePicker,
+  VariableControl,
+} from '@grafana/scenes-react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import React from 'react';
+
+import { ROUTES } from '../../constants';
+import datasourcePluginJson from '../../datasource/plugin.json';
+import resourcesImg from '../../img/logo.svg';
+import pluginJson from '../../plugin.json';
+import { prefixRoute } from '../../utils/utils.routing';
+import { getStyles } from '../../utils/utils.styles';
+import { SearchPagePods } from './SearchPagePods';
+import { SearchPageWorkloads } from './SearchPageWorkloads';
+
+export function SearchPage() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <SceneContextProvider
+      timeRange={{ from: `now-1h`, to: 'now' }}
+      withQueryController
+    >
+      <DataSourceVariable
+        name="datasource"
+        label="Cluster"
+        pluginId={datasourcePluginJson.id}
+        refresh={VariableRefresh.onDashboardLoad}
+      >
+        <QueryVariable
+          skipUrlSync={true}
+          name="prometheus"
+          label="Prometheus"
+          datasource={{ type: datasourcePluginJson.id, uid: '$datasource' }}
+          query={{
+            refId: 'settings',
+            queryType: 'settings',
+            setting: 'integrationsMetricsDatasourceUid',
+            variableField: 'values',
+          }}
+          refresh={VariableRefresh.onDashboardLoad}
+          hide={VariableHide.hideVariable}
+        >
+          <QueryVariable
+            skipUrlSync={true}
+            name="cluster"
+            label="Cluster Label"
+            datasource={{ type: datasourcePluginJson.id, uid: '$datasource' }}
+            query={{
+              refId: 'settings',
+              queryType: 'settings',
+              setting: 'integrationsMetricsClusterLabel',
+              variableField: 'values',
+            }}
+            refresh={VariableRefresh.onDashboardLoad}
+            hide={VariableHide.hideVariable}
+          >
+            <CustomVariable
+              name="searchterm"
+              label="Search Term"
+              query=".+"
+              initialValue=".+"
+            >
+              <PluginPage
+                pageNav={{
+                  text: 'Search',
+                  parentItem: {
+                    text: 'Kubernetes',
+                    url: prefixRoute(ROUTES.Home),
+                  },
+                }}
+                renderTitle={() => (
+                  <Stack gap={0} alignItems="center" direction="row">
+                    <img
+                      className={styles.pluginPage.title.image}
+                      alt="Search"
+                      src={resourcesImg}
+                    />
+                    <h1>Search</h1>
+                  </Stack>
+                )}
+                subTitle={pluginJson.info.description}
+                actions={
+                  <>
+                    <TimeRangePicker />
+                    <RefreshPicker />
+                  </>
+                }
+              >
+                <Stack direction="column" gap={2}>
+                  <div className={styles.dashboard.header.container}>
+                    <VariableControl name="datasource" />
+                    <VariableControl name="searchterm" />
+                    <div className={styles.dashboard.header.spacer} />
+                  </div>
+                  <div className={styles.dashboard.row.height400px}>
+                    <SearchPageWorkloads />
+                  </div>
+                  <div className={styles.dashboard.row.height400px}>
+                    <SearchPagePods />
+                  </div>
+                </Stack>
+              </PluginPage>
+            </CustomVariable>
+          </QueryVariable>
+        </QueryVariable>
+      </DataSourceVariable>
+    </SceneContextProvider>
+  );
+}

--- a/src/components/search/SearchPagePods.tsx
+++ b/src/components/search/SearchPagePods.tsx
@@ -1,0 +1,102 @@
+import { DataTransformerID } from '@grafana/data';
+import { VizConfigBuilders } from '@grafana/scenes';
+import {
+  useDataTransformer,
+  useQueryRunner,
+  VizPanel,
+} from '@grafana/scenes-react';
+import React from 'react';
+
+import { ROUTES } from '../../constants';
+import { useVizPanelMenu } from '../../hooks/useVizPanelMenu';
+import { queries } from '../../utils/utils.queries';
+import { prefixRoute } from '../../utils/utils.routing';
+
+export function SearchPagePods() {
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: [
+      {
+        refId: 'info',
+        format: 'table',
+        instant: true,
+        expr: queries.pods.search,
+      },
+    ],
+  });
+
+  const dataTransformer = useDataTransformer({
+    data: dataProvider,
+    transformations: [
+      {
+        id: DataTransformerID.organize,
+        options: {
+          includeByName: {
+            ['namespace']: true,
+            ['pod']: true,
+          },
+          indexByName: {
+            ['namespace']: 0,
+            ['pod']: 1,
+          },
+          renameByName: {
+            ['namespace']: 'NAMESPACE',
+            ['pod']: 'POD',
+          },
+        },
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.table()
+    .setOption('sortBy', [
+      {
+        desc: false,
+        displayName: 'NAMESPACE',
+      },
+      {
+        desc: false,
+        displayName: 'POD',
+      },
+    ])
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('namespace')
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsNamespaces)}/\${__value.raw}?\${__url_time_range}&var-datasource=$datasource`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('pod')
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsPods)}/\${__data.fields["namespace"].text}/\${__value.raw}?\${__url_time_range}&var-datasource=$datasource`,
+          },
+        ])
+        .build();
+    })
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title="Pods"
+      menu={menu}
+      viz={viz}
+      dataProvider={dataTransformer}
+    />
+  );
+}

--- a/src/components/search/SearchPageWorkloads.tsx
+++ b/src/components/search/SearchPageWorkloads.tsx
@@ -1,0 +1,112 @@
+import { DataTransformerID } from '@grafana/data';
+import { VizConfigBuilders } from '@grafana/scenes';
+import {
+  useDataTransformer,
+  useQueryRunner,
+  VizPanel,
+} from '@grafana/scenes-react';
+import React from 'react';
+
+import { ROUTES } from '../../constants';
+import { useVizPanelMenu } from '../../hooks/useVizPanelMenu';
+import { queries } from '../../utils/utils.queries';
+import { prefixRoute } from '../../utils/utils.routing';
+
+export function SearchPageWorkloads() {
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: [
+      {
+        refId: 'info',
+        format: 'table',
+        instant: true,
+        expr: queries.workloads.search,
+      },
+    ],
+  });
+
+  const dataTransformer = useDataTransformer({
+    data: dataProvider,
+    transformations: [
+      {
+        id: DataTransformerID.organize,
+        options: {
+          includeByName: {
+            ['namespace']: true,
+            ['workload']: true,
+            ['workload_type']: true,
+          },
+          indexByName: {
+            ['namespace']: 0,
+            ['workload']: 1,
+            ['workload_type']: 2,
+          },
+          renameByName: {
+            ['namespace']: 'NAMESPACE',
+            ['workload']: 'WORKLOAD',
+            ['workload_type']: 'WORKLOAD TYPE',
+          },
+        },
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.table()
+    .setOption('sortBy', [
+      {
+        desc: false,
+        displayName: 'NAMESPACE',
+      },
+      {
+        desc: false,
+        displayName: 'WORKLOAD',
+      },
+      {
+        desc: false,
+        displayName: 'WORKLOAD TYPE',
+      },
+    ])
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('namespace')
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsNamespaces)}/\${__value.raw}?\${__url_time_range}&var-datasource=$datasource`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('workload')
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.MetricsWorkloads)}/\${__data.fields["namespace"].text}/\${__data.fields["workload_type"].text}/\${__value.raw}?\${__url_time_range}&var-datasource=$datasource`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b.matchFieldsWithName('workload_type').build();
+    })
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title="Workloads"
+      menu={menu}
+      viz={viz}
+      dataProvider={dataTransformer}
+    />
+  );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const PLUGIN_BASE_URL = `/a/${pluginJson.id}`;
 
 export enum ROUTES {
   Home = 'home',
+  Search = 'search',
   Resources = 'resources',
   Helm = 'helm',
   Kubeconfig = 'kubeconfig',

--- a/src/utils/utils.queries.ts
+++ b/src/utils/utils.queries.ts
@@ -4405,6 +4405,11 @@ label_join(
     )
   ) by(cluster,namespace,pod)
 ) by(cluster,namespace,workload,workload_type)`,
+    search: `sum(
+  namespace_workload_pod:kube_pod_owner:relabel{
+    cluster=~"$cluster",namespace=~".+",workload=~"$searchterm"
+  }
+) by(namespace,workload,workload_type)`,
   },
   pods: {
     count: `count(kube_pod_info{cluster=~"$cluster", namespace=~"$namespace", pod!=""})`,
@@ -5380,6 +5385,11 @@ sum(
     ) by(cluster,node)
   )[$__range:1h]
 )`,
+    search: `sum(
+  namespace_workload_pod:kube_pod_owner:relabel{
+    cluster=~"$cluster",namespace=~".+",pod=~"$searchterm"
+  }
+) by(namespace,pod)`,
   },
   containers: {
     labelsByClusterNamespacePod: `label_values(

--- a/src/utils/utils.styles.ts
+++ b/src/utils/utils.styles.ts
@@ -46,6 +46,9 @@ export function getStyles(theme: GrafanaTheme2) {
         spacer: css({
           flex: 1,
         }),
+        search: css({
+          margin: 0,
+        }),
       },
       row: {
         height100percent: css({


### PR DESCRIPTION
The hoem page of the plugin contains a search field now, which allows
users to search for workloads and pods. The search results are displayed
on a separate search page, in two different tables, one for workloads
and one for pods.
