### PR TITLE
fix(panels): explore links for VictoriaLogs

### DIFF
--- a/src/hooks/useVizPanelMenu.tsx
+++ b/src/hooks/useVizPanelMenu.tsx
@@ -7,11 +7,19 @@ import {
 } from '@grafana/scenes';
 import { useTimeRange, useVariableInterpolator } from '@grafana/scenes-react';
 
+/**
+ * Correct the scene variable interpoldation.
+ *
+ * NOTE: The second replace (`replace(/(:in\()\{(.*?)\}/, '$1$2')`) is used, to
+ * make it also work for VictoriaLogs datasource.
+ */
 function correctSceneVariableInterpolation(input: string) {
-  return input.replace(
-    /(\w+)=~"\{([^}]+)\}"/g,
-    (_, key, values) => `${key}=~"${values.split(',').join('|')}"`,
-  );
+  return input
+    .replace(
+      /(\w+)=~"\{([^}]+)\}"/g,
+      (_, key, values) => `${key}=~"${values.split(',').join('|')}"`,
+    )
+    .replace(/(:in\()\{(.*?)\}/, '$1$2');
 }
 
 interface UseVizPanelMenuProps {


### PR DESCRIPTION
If VictoriaLogs is used for the logs section of workloads with an
`in:(${pods})` expression, the explore links were not working correctly
because the variable interpolation was not correctly applied to the
links. This is now fixed.
