### PR TITLE
feat(alerts): add alerts tab to home page

### DIFF
--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -14,6 +14,7 @@ import React, { useState } from 'react';
 import datasourcePluginJson from '../../datasource/plugin.json';
 import pluginJson from '../../plugin.json';
 import { getStyles } from '../../utils/utils.styles';
+import { HomePageAlerts } from './HomePageAlerts';
 import { HomePageCost } from './HomePageCost';
 import { HomePageOverview } from './HomePageOverview';
 
@@ -111,6 +112,14 @@ export function HomePage() {
                           }}
                         />
                         <Tab
+                          label="Alerts"
+                          active={activeTab === 'alerts'}
+                          onChangeTab={(ev) => {
+                            ev?.preventDefault();
+                            setActiveTab('alerts');
+                          }}
+                        />
+                        <Tab
                           label="Cost"
                           active={activeTab === 'cost'}
                           onChangeTab={(ev) => {
@@ -121,6 +130,7 @@ export function HomePage() {
                       </TabsBar>
 
                       {activeTab === 'overview' && <HomePageOverview />}
+                      {activeTab === 'alerts' && <HomePageAlerts />}
                       {activeTab === 'cost' && <HomePageCost />}
                     </PluginPage>
                   </CustomVariable>

--- a/src/components/home/HomePageAlerts.tsx
+++ b/src/components/home/HomePageAlerts.tsx
@@ -1,0 +1,30 @@
+import { VariableControl } from '@grafana/scenes-react';
+import { Stack, useStyles2 } from '@grafana/ui';
+import React from 'react';
+
+import { getStyles } from '../../utils/utils.styles';
+import { TableAlerts } from './TableAlerts';
+import { TimeSeriesAlertsByNamespace } from './TimeSeriesAlertsByNamespace';
+import { TimeSeriesAlertsBySeverity } from './TimeSeriesAlertsBySeverity';
+
+export function HomePageAlerts() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <div className={styles.dashboard.header.container}>
+        <VariableControl name="datasource" />
+        <div className={styles.dashboard.header.spacer} />
+      </div>
+      <Stack direction="column" gap={2}>
+        <div className={styles.dashboard.row.height400px}>
+          <TimeSeriesAlertsBySeverity />
+          <TimeSeriesAlertsByNamespace />
+        </div>
+        <div className={styles.dashboard.row.height400px}>
+          <TableAlerts />
+        </div>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/components/home/TableAlerts.tsx
+++ b/src/components/home/TableAlerts.tsx
@@ -1,0 +1,218 @@
+import { DataTransformerID, MappingType } from '@grafana/data';
+import { VizConfigBuilders } from '@grafana/scenes';
+import {
+  useDataTransformer,
+  useQueryRunner,
+  VizPanel,
+} from '@grafana/scenes-react';
+import { TableCellDisplayMode } from '@grafana/schema';
+import React from 'react';
+
+import { ROUTES } from '../../constants';
+import { useVizPanelMenu } from '../../hooks/useVizPanelMenu';
+import { queries } from '../../utils/utils.queries';
+import { prefixRoute } from '../../utils/utils.routing';
+
+export function TableAlerts() {
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: [
+      {
+        refId: 'alerts',
+        format: 'table',
+        instant: true,
+        expr: queries.cluster.alerts,
+      },
+    ],
+  });
+
+  const dataTransformer = useDataTransformer({
+    data: dataProvider,
+    transformations: [
+      {
+        id: DataTransformerID.joinByField,
+        options: {
+          byField: 'join_key',
+          mode: 'outer',
+        },
+      },
+      {
+        id: DataTransformerID.organize,
+        options: {
+          includeByName: {
+            ['alertname']: true,
+            ['severity']: true,
+            ['node']: true,
+            ['namespace']: true,
+            ['persistentvolumeclaim']: true,
+            ['workload']: true,
+            ['workload_type']: true,
+            ['pod']: true,
+            ['container']: true,
+            ['reason']: true,
+          },
+          indexByName: {
+            ['alertname']: 0,
+            ['severity']: 1,
+            ['node']: 2,
+            ['namespace']: 3,
+            ['persistentvolumeclaim']: 4,
+            ['workload']: 5,
+            ['workload_type']: 6,
+            ['pod']: 7,
+            ['container']: 8,
+            ['reason']: 9,
+          },
+          renameByName: {
+            ['alertname']: 'ALERTNAME',
+            ['severity']: 'SEVERITY',
+            ['node']: 'NODE',
+            ['namespace']: 'NAMESPACE',
+            ['persistentvolumeclaim']: 'PVC',
+            ['workload']: 'WORKLOAD',
+            ['workload_type']: 'WORKLOAD TYPE',
+            ['pod']: 'POD',
+            ['container']: 'CONTAINER',
+            ['reason']: 'REASON',
+          },
+        },
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.table()
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('alertname')
+        .overrideCustomFieldConfig('width', 300)
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('severity')
+        .overrideCustomFieldConfig('width', 100)
+        .overrideCustomFieldConfig('cellOptions', {
+          type: TableCellDisplayMode.ColorText,
+        })
+        .overrideMappings([
+          {
+            options: {
+              ['critical']: {
+                color: 'purpel',
+                index: 0,
+              },
+              ['error']: {
+                color: 'red',
+                index: 1,
+              },
+              ['warning']: {
+                color: 'orange',
+                index: 2,
+              },
+              ['info']: {
+                color: 'blue',
+                index: 3,
+              },
+            },
+            type: MappingType.ValueToText,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('node')
+        .overrideCustomFieldConfig('width', 200)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.Nodes)}/\${__value.raw}?\${__url_time_range}&var-datasource=$datasource`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('namespace')
+        .overrideCustomFieldConfig('width', 200)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.Namespaces)}/\${__value.raw}?\${__url_time_range}&var-datasource=$datasource`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('persistentvolumeclaim')
+        .overrideCustomFieldConfig('width', 200)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.PersistentVolumeClaims)}/\${__data.fields["namespace"].text}/\${__value.raw}?\${__url_time_range}&var-datasource=$datasource`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('workload')
+        .overrideCustomFieldConfig('width', 200)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.Workloads)}/\${__data.fields["namespace"].text}/\${__data.fields["workload_type"].text}/\${__value.raw}?\${__url_time_range}&var-datasource=$datasource`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('workload_type')
+        .overrideCustomFieldConfig('width', 150)
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('pod')
+        .overrideCustomFieldConfig('width', 300)
+        .overrideLinks([
+          {
+            title: '',
+            url: `${prefixRoute(ROUTES.Pods)}/\${__data.fields["namespace"].text}/\${__value.raw}?\${__url_time_range}&var-datasource=$datasource`,
+          },
+        ])
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('container')
+        .overrideCustomFieldConfig('width', 200)
+        .build();
+    })
+    .setOverrides((b) => {
+      return b
+        .matchFieldsWithName('reason')
+        .overrideCustomFieldConfig('width', 300)
+        .build();
+    })
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title="Alerts"
+      menu={menu}
+      viz={viz}
+      dataProvider={dataTransformer}
+    />
+  );
+}

--- a/src/components/home/TimeSeriesAlertsByNamespace.tsx
+++ b/src/components/home/TimeSeriesAlertsByNamespace.tsx
@@ -1,0 +1,50 @@
+import { VizConfigBuilders } from '@grafana/scenes';
+import { useQueryRunner, VizPanel } from '@grafana/scenes-react';
+import { LegendDisplayMode } from '@grafana/schema';
+import React from 'react';
+
+import { useVizPanelMenu } from '../../hooks/useVizPanelMenu';
+import { queries } from '../../utils/utils.queries';
+
+export function TimeSeriesAlertsByNamespace() {
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: [
+      {
+        refId: 'alerts_by_namespace',
+        format: 'time_series',
+        interval: '$__rate_interval',
+        expr: queries.cluster.alertsByNamespace,
+        legendFormat: '{{namespace}}',
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setUnit('short')
+    .setOption('legend', {
+      asTable: true,
+      displayMode: LegendDisplayMode.Table,
+      placement: 'bottom',
+      calcs: ['last'],
+    })
+    .setCustomFieldConfig('fillOpacity', 10)
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title="Alert Severity"
+      menu={menu}
+      viz={viz}
+      dataProvider={dataProvider}
+    />
+  );
+}

--- a/src/components/home/TimeSeriesAlertsBySeverity.tsx
+++ b/src/components/home/TimeSeriesAlertsBySeverity.tsx
@@ -1,0 +1,80 @@
+import { VizConfigBuilders } from '@grafana/scenes';
+import { useQueryRunner, VizPanel } from '@grafana/scenes-react';
+import { LegendDisplayMode } from '@grafana/schema';
+import React from 'react';
+
+import { useVizPanelMenu } from '../../hooks/useVizPanelMenu';
+import { queries } from '../../utils/utils.queries';
+
+export function TimeSeriesAlertsBySeverity() {
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: [
+      {
+        refId: 'alerts_by_severity',
+        format: 'time_series',
+        interval: '$__rate_interval',
+        expr: queries.cluster.alertsBySeverity,
+        legendFormat: '{{severity}}',
+      },
+    ],
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setUnit('short')
+    .setOption('legend', {
+      asTable: true,
+      displayMode: LegendDisplayMode.Table,
+      placement: 'bottom',
+      calcs: ['last'],
+    })
+    .setCustomFieldConfig('fillOpacity', 10)
+    .setOverrides((b) =>
+      b.matchFieldsWithNameByRegex('.*').overrideColor({
+        mode: 'fixed',
+        fixedColor: 'green',
+      }),
+    )
+    .setOverrides((b) =>
+      b.matchFieldsWithName('critical').overrideColor({
+        mode: 'fixed',
+        fixedColor: 'purple',
+      }),
+    )
+    .setOverrides((b) =>
+      b.matchFieldsWithName('error').overrideColor({
+        mode: 'fixed',
+        fixedColor: 'red',
+      }),
+    )
+    .setOverrides((b) =>
+      b.matchFieldsWithName('warning').overrideColor({
+        mode: 'fixed',
+        fixedColor: 'orange',
+      }),
+    )
+    .setOverrides((b) =>
+      b.matchFieldsWithName('info').overrideColor({
+        mode: 'fixed',
+        fixedColor: 'blue',
+      }),
+    )
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel
+      title="Alert Severity"
+      menu={menu}
+      viz={viz}
+      dataProvider={dataProvider}
+    />
+  );
+}

--- a/src/components/namespaces/NamespacePageOverview.tsx
+++ b/src/components/namespaces/NamespacePageOverview.tsx
@@ -106,7 +106,6 @@ function Workloads() {
               }
               desiredPodsExpr={queries.workloads.desiredPods}
               readyPodsExpr={queries.workloads.readyPods}
-              alertsExpr={queries.workloads.alertsCount}
             />
           )}
           {selected === 'cost' && (

--- a/src/components/namespaces/NamespacesPage.tsx
+++ b/src/components/namespaces/NamespacesPage.tsx
@@ -11,8 +11,8 @@ import {
 import { Stack, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
-import resourcesImg from '../../img/logo.svg';
 import datasourcePluginJson from '../../datasource/plugin.json';
+import resourcesImg from '../../img/logo.svg';
 import pluginJson from '../../plugin.json';
 import { queries, variableQuery } from '../../utils/utils.queries';
 import { getStyles } from '../../utils/utils.styles';
@@ -129,7 +129,6 @@ export function NamespacesPage() {
                       memoryUsageMaxPercentExpr={
                         queries.namespaces.memoryUsageMaxPercentOverTime
                       }
-                      alertsExpr={queries.namespaces.alertsCount}
                     />
                   </div>
                 </Stack>

--- a/src/components/nodes/NodePageOverview.tsx
+++ b/src/components/nodes/NodePageOverview.tsx
@@ -99,7 +99,6 @@ function Pods() {
               memoryUsageMaxPercentExpr={
                 queries.pods.memoryUsageMaxPercentOverTime
               }
-              alertsExpr={queries.pods.alertsCount}
             />
           )}
           {selected === 'cost' && (

--- a/src/components/nodes/NodesPage.tsx
+++ b/src/components/nodes/NodesPage.tsx
@@ -106,7 +106,6 @@ export function NodesPage() {
                     memoryUsageMaxPercentExpr={
                       queries.nodes.memoryUsageMaxPercentOverTime
                     }
-                    alertsExpr={queries.nodes.alertsCount}
                   />
                 </div>
               </Stack>

--- a/src/components/persistentcolumeclaims/PersistentVolumeClaimPage.tsx
+++ b/src/components/persistentcolumeclaims/PersistentVolumeClaimPage.tsx
@@ -269,7 +269,6 @@ function Pods() {
               memoryUsageMaxPercentExpr={
                 queries.pods.memoryUsageMaxPercentOverTime
               }
-              alertsExpr={queries.pods.alertsCount}
             />
           )}
           {selected === 'info' && <TableKubernetesPods />}

--- a/src/components/pods/PodsPage.tsx
+++ b/src/components/pods/PodsPage.tsx
@@ -158,7 +158,6 @@ export function PodsPage() {
                           memoryUsageMaxPercentExpr={
                             queries.pods.memoryUsageMaxPercentOverTime
                           }
-                          alertsExpr={queries.pods.alertsCount}
                         />
                       </div>
                     </Stack>

--- a/src/components/shared/TableResourceUsage.tsx
+++ b/src/components/shared/TableResourceUsage.tsx
@@ -28,7 +28,6 @@ interface Props {
   memoryUsageMaxPercentExpr?: string;
   desiredPodsExpr?: string;
   readyPodsExpr?: string;
-  alertsExpr?: string;
 }
 
 export function TableResourceUsage({
@@ -47,7 +46,6 @@ export function TableResourceUsage({
   memoryUsageMaxPercentExpr,
   desiredPodsExpr,
   readyPodsExpr,
-  alertsExpr,
 }: Props) {
   const queries: SceneDataQuery[] = [];
 
@@ -163,14 +161,6 @@ export function TableResourceUsage({
       expr: readyPodsExpr,
     });
   }
-  if (alertsExpr) {
-    queries.push({
-      refId: 'alerts',
-      format: 'table',
-      instant: true,
-      expr: alertsExpr,
-    });
-  }
 
   const dataProvider = useQueryRunner({
     datasource: {
@@ -224,7 +214,6 @@ export function TableResourceUsage({
             ['Value #memory_usage_max']: true,
             ['Value #memory_usage_max_percent']: true,
             ['Value #ready_pods / Value #desired_pods']: true,
-            ['Value #alerts']: true,
           },
           indexByName: {
             ['namespace']: 0,
@@ -245,7 +234,6 @@ export function TableResourceUsage({
             ['Value #memory_usage_max']: 14,
             ['Value #memory_usage_max_percent']: 15,
             ['Value #ready_pods / Value #desired_pods']: 16,
-            ['Value #alerts']: 17,
           },
           renameByName: {
             ['node']: 'NODE',
@@ -266,7 +254,6 @@ export function TableResourceUsage({
             ['Value #memory_usage_max']: 'MEM MAX',
             ['Value #memory_usage_max_percent']: 'MEM MAX %',
             ['Value #ready_pods / Value #desired_pods']: 'READY',
-            ['Value #alerts']: 'ALERTS',
           },
         },
       },
@@ -550,23 +537,6 @@ export function TableResourceUsage({
             {
               color: 'green',
               value: 0.9,
-            },
-          ],
-        }),
-    )
-    .setOverrides((b) =>
-      b
-        .matchFieldsWithName('Value #alerts')
-        .overrideCustomFieldConfig('width', 100)
-        .overrideCustomFieldConfig('cellOptions', {
-          type: TableCellDisplayMode.ColorText,
-        })
-        .overrideThresholds({
-          mode: ThresholdsMode.Absolute,
-          steps: [
-            {
-              color: 'red',
-              value: 1,
             },
           ],
         }),

--- a/src/components/workloads/WorkloadPageOverview.tsx
+++ b/src/components/workloads/WorkloadPageOverview.tsx
@@ -289,7 +289,6 @@ function Pods() {
               memoryUsageMaxPercentExpr={
                 queries.pods.memoryUsageMaxPercentOverTime
               }
-              alertsExpr={queries.pods.alertsCount}
             />
           )}
           {selected === 'cost' && (

--- a/src/components/workloads/WorkloadsPage.tsx
+++ b/src/components/workloads/WorkloadsPage.tsx
@@ -152,7 +152,6 @@ export function WorkloadsPage() {
                         }
                         desiredPodsExpr={queries.workloads.desiredPods}
                         readyPodsExpr={queries.workloads.readyPods}
-                        alertsExpr={queries.workloads.alertsCount}
                       />
                     </div>
                   </Stack>

--- a/src/utils/utils.queries.ts
+++ b/src/utils/utils.queries.ts
@@ -381,6 +381,170 @@ vector(0)`,
 )
   *
 30`,
+    alertsBySeverity: `count(
+  ALERTS{
+    alertname=~"(Kube.*|CPUThrottlingHigh)",
+    alertstate=~"firing",
+    cluster=~"$cluster",
+    severity!=""
+  }
+    or
+  GRAFANA_ALERTS{
+    alertname=~"(Kube.*|CPUThrottlingHigh)",
+    alertstate=~"firing",
+    cluster=~"$cluster",
+    severity!=""
+
+  }
+) by(severity)`,
+    alertsByNamespace: `count(
+  ALERTS{
+    alertname=~"(Kube.*|CPUThrottlingHigh)",
+    alertstate=~"firing",
+    cluster=~"$cluster",
+    namespace!=""
+
+  }
+    or
+  GRAFANA_ALERTS{
+    alertname=~"(Kube.*|CPUThrottlingHigh)",
+    alertstate=~"firing",
+    cluster=~"$cluster",
+    namespace!=""
+
+  }
+) by(namespace)`,
+    alerts: `(
+  (
+    (
+      (
+        label_replace(
+          label_replace(
+            ALERTS{
+              daemonset!="",
+              alertname=~"(Kube.*|CPUThrottlingHigh)",
+              alertstate=~"firing",
+              cluster=~"$cluster"
+            }
+              or
+            GRAFANA_ALERTS{
+              daemonset!="",
+              alertname=~"(Kube.*|CPUThrottlingHigh)",
+              alertstate=~"firing",
+              cluster=~"$cluster"
+            },
+            "workload_type",
+            "",
+            "daemonset",
+            ""
+          ),
+          "workload",
+          "$1",
+          "daemonset",
+          "(.*)"
+        )
+          or
+        label_replace(
+          label_replace(
+            ALERTS{
+              deployment!="",
+              alertname=~"(Kube.*|CPUThrottlingHigh)",
+              alertstate=~"firing",
+              cluster=~"$cluster"
+            }
+              or
+            GRAFANA_ALERTS{
+              deployment!="",
+              alertname=~"(Kube.*|CPUThrottlingHigh)",
+              alertstate=~"firing",
+              cluster=~"$cluster"
+            },
+            "workload_type",
+            "",
+            "deployment",
+            ""
+          ),
+          "workload",
+          "$1",
+          "deployment",
+          "(.*)"
+        )
+      )
+        or
+      label_replace(
+        label_replace(
+          ALERTS{
+            statefulset!="",
+            alertname=~"(Kube.*|CPUThrottlingHigh)",
+            alertstate=~"firing",
+            cluster=~"$cluster"
+          }
+            or
+          GRAFANA_ALERTS{
+            statefulset!="",
+            alertname=~"(Kube.*|CPUThrottlingHigh)",
+            alertstate=~"firing",
+            cluster=~"$cluster"
+          },
+          "workload_type",
+          "",
+          "statefulset",
+          ""
+        ),
+        "workload",
+        "$1",
+        "statefulset",
+        "(.*)"
+      )
+    )
+      or
+    label_replace(
+      label_replace(
+        ALERTS{
+          job_name!="",
+          alertname=~"(Kube.*|CPUThrottlingHigh)",
+          alertstate=~"firing",
+          cluster=~"$cluster"
+        }
+          or
+        GRAFANA_ALERTS{
+          job_name!="",
+          alertname=~"(Kube.*|CPUThrottlingHigh)",
+          alertstate=~"firing",
+          cluster=~"$cluster"
+        },
+        "workload_type",
+        "",
+        "job",
+        ""
+      ),
+      "workload",
+      "$1",
+      "job_name",
+      "(.*)"
+    )
+  )
+    or
+  ALERTS{
+    daemonset="",
+    deployment="",
+    statefulset="",
+    job_name="",
+    alertname=~"(Kube.*|CPUThrottlingHigh)",
+    alertstate=~"firing",
+    cluster=~"$cluster"
+  }
+)
+  or
+GRAFANA_ALERTS{
+  daemonset="",
+  deployment="",
+  statefulset="",
+  job_name="",
+  alertname=~"(Kube.*|CPUThrottlingHigh)",
+  alertstate=~"firing",
+  cluster=~"$cluster"
+}`,
   },
   nodes: {
     info: `avg_over_time(
@@ -699,22 +863,6 @@ max(
 max(
   kube_node_status_capacity{cluster=~"$cluster",resource=~"memory",node=~".+"}
 ) by(cluster,node,resource)`,
-    alertsCount: `count(
-  ALERTS{node!="",alertname=~"(Kube.*|CPUThrottlingHigh)",alertstate=~"firing"}
-    or
-  (
-    max(
-      ALERTS{
-        node="",
-        pod!="",
-        alertname=~"(Kube.*|CPUThrottlingHigh)",
-        alertstate=~"firing"
-      }
-    ) by(cluster,namespace,pod)
-      * on(cluster,namespace,pod) group_left(node)
-    max(kube_pod_info{node!="",node!=""}) by(cluster,namespace,pod,node)
-  )
-) by(cluster,node)`,
     cpuCapacity: `max(
   kube_node_status_capacity{
     cluster=~"$cluster",
@@ -1584,14 +1732,6 @@ sum(
 sum(
   namespace_memory:kube_pod_container_resource_requests:sum{
     cluster=~"$cluster",namespace=~"$namespace"
-  }
-) by(cluster,namespace)`,
-    alertsCount: `count(
-  ALERTS{
-    alertname=~"(Kube.*|CPUThrottlingHigh)",
-    alertstate=~"firing",
-    cluster=~"$cluster",
-    namespace=~"$namespace"
   }
 ) by(cluster,namespace)`,
     cpuAllocation: `max(
@@ -2981,143 +3121,6 @@ sum(
       resource="memory"
     }
   ) by(cluster,namespace,pod)
-) by(cluster,namespace,workload,workload_type)`,
-    alertsCount: `sum(
-  (
-    (
-      (
-        (
-          (
-            group(
-              ALERTS{
-                alertname=~"(Kube.*|CPUThrottlingHigh)",
-                alertstate=~"firing",
-                cluster=~"$cluster",
-                namespace=~"$namespace",
-                pod=~".+-.+"
-              }
-            ) by(cluster,namespace,pod)
-              * on(cluster,namespace,pod) group_left(workload,workload_type)
-            topk(
-              1,
-              group(
-                namespace_workload_pod:kube_pod_owner:relabel{
-                  cluster=~"$cluster",
-                  namespace=~"$namespace",
-                  workload=~"$workload"
-                }
-              ) by(cluster,namespace,workload,workload_type,pod)
-            ) by(cluster,namespace,pod)
-          )
-            or
-          label_replace(
-            label_replace(
-              ALERTS{
-                alertname=~"(Kube.*|CPUThrottlingHigh)",
-                alertstate=~"firing",
-                cluster=~"$cluster",
-                namespace=~"$namespace",
-                pod=~"",
-                replicaset=~"$workload"
-              },
-              "workload_type",
-              "",
-              "replicaset",
-              ""
-            ),
-            "workload",
-            "$1",
-            "replicaset",
-            "(.*)"
-          )
-        )
-          or
-        label_replace(
-          label_replace(
-            ALERTS{
-              alertname=~"(Kube.*|CPUThrottlingHigh)",
-              alertstate=~"firing",
-              cluster=~"$cluster",
-              namespace=~"$namespace",
-              pod=~"",
-              daemonset=~"$workload"
-            },
-            "workload_type",
-            "",
-            "daemonset",
-            ""
-          ),
-          "workload",
-          "$1",
-          "daemonset",
-          "(.*)"
-        )
-      )
-        or
-      label_replace(
-        label_replace(
-          ALERTS{
-            alertname=~"(Kube.*|CPUThrottlingHigh)",
-            alertstate=~"firing",
-            cluster=~"$cluster",
-            namespace=~"$namespace",
-            pod=~"",
-            deployment=~"$workload"
-          },
-          "workload_type",
-          "",
-          "deployment",
-          ""
-        ),
-        "workload",
-        "$1",
-        "deployment",
-        "(.*)"
-      )
-    )
-      or
-    label_replace(
-      label_replace(
-        ALERTS{
-          alertname=~"(Kube.*|CPUThrottlingHigh)",
-          alertstate=~"firing",
-          cluster=~"$cluster",
-          namespace=~"$namespace",
-          pod=~"",
-          statefulset=~"$workload"
-        },
-        "workload_type",
-        "",
-        "statefulset",
-        ""
-      ),
-      "workload",
-      "$1",
-      "statefulset",
-      "(.*)"
-    )
-  )
-    or
-  label_replace(
-    label_replace(
-      ALERTS{
-        alertname=~"(Kube.*|CPUThrottlingHigh)",
-        alertstate=~"firing",
-        cluster=~"$cluster",
-        namespace=~"$namespace",
-        pod=~"",
-        job_name=~"$workload"
-      },
-      "workload_type",
-      "",
-      "job",
-      ""
-    ),
-    "workload",
-    "$1",
-    "job_name",
-    "(.*)"
-  )
 ) by(cluster,namespace,workload,workload_type)`,
     cpuAllocation: `max(
   sum(
@@ -4629,13 +4632,6 @@ sum(
     resource="memory"
   }
 ) by(cluster,namespace,pod)`,
-    alertsCount: `ALERTS{
-  pod=~"$pod",
-  alertname=~"(Kube.*|CPUThrottlingHigh)",
-  alertstate=~"firing",
-  cluster=~"$cluster",
-  namespace=~"$namespace"
-}`,
     cpuAllocation: `max(
   sum(
     max(


### PR DESCRIPTION
This commit adds an alerts tab to the home page, which shows the alerts
by severity and namespace and a table of all Kubernetes related alerts.

The alerts column from nodes, namespaces, workloads and pods was
removed.
