### PR TITLE
feat(tabs): persist active tab in url

### DIFF
--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -9,19 +9,20 @@ import {
   TimeRangePicker,
 } from '@grafana/scenes-react';
 import { Tab, TabsBar, useStyles2 } from '@grafana/ui';
-import React, { useState } from 'react';
+import React from 'react';
 
 import datasourcePluginJson from '../../datasource/plugin.json';
+import { useActiveTab } from '../../hooks/useActiveTab';
 import pluginJson from '../../plugin.json';
 import { getStyles } from '../../utils/utils.styles';
+import { PageOptions } from '../shared/PageOptions';
 import { HomePageAlerts } from './HomePageAlerts';
 import { HomePageCost } from './HomePageCost';
 import { HomePageOverview } from './HomePageOverview';
-import { PageOptions } from '../shared/PageOptions';
 
 export function HomePage() {
   const styles = useStyles2(getStyles);
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activeTab, setActiveTab] = useActiveTab('overview');
 
   return (
     <SceneContextProvider

--- a/src/components/namespaces/NamespacePage.tsx
+++ b/src/components/namespaces/NamespacePage.tsx
@@ -9,28 +9,29 @@ import {
   TimeRangePicker,
 } from '@grafana/scenes-react';
 import { Alert, Badge, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
-import React, { useState } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ROUTES } from '../../constants';
 import datasourcePluginJson from '../../datasource/plugin.json';
+import { useActiveTab } from '../../hooks/useActiveTab';
 import resourcesImg from '../../img/logo.svg';
 import pluginJson from '../../plugin.json';
 import { queries, variableQuery } from '../../utils/utils.queries';
 import { prefixRoute } from '../../utils/utils.routing';
 import { getStyles } from '../../utils/utils.styles';
+import { PageOptions } from '../shared/PageOptions';
 import { TabLogs } from '../shared/TabLogs';
 import { NamespacePageCPU } from './NamespacePageCPU';
 import { NamespacePageMemory } from './NamespacePageMemory';
 import { NamespacePageNetwork } from './NamespacePageNetwork';
 import { NamespacePageOverview } from './NamespacePageOverview';
 import { NamespacePageStorage } from './NamespacePageStorage';
-import { PageOptions } from '../shared/PageOptions';
 
 export function NamespacePage() {
   const styles = useStyles2(getStyles);
   const { namespace } = useParams<{ namespace: string }>();
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activeTab, setActiveTab] = useActiveTab('overview');
 
   if (!namespace) {
     return <Alert title="Namespace not found" severity="error" />;

--- a/src/components/nodes/NodePage.tsx
+++ b/src/components/nodes/NodePage.tsx
@@ -9,11 +9,12 @@ import {
   TimeRangePicker,
 } from '@grafana/scenes-react';
 import { Alert, Badge, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
-import React, { useState } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ROUTES } from '../../constants';
 import datasourcePluginJson from '../../datasource/plugin.json';
+import { useActiveTab } from '../../hooks/useActiveTab';
 import resourcesImg from '../../img/logo.svg';
 import pluginJson from '../../plugin.json';
 import { queries, variableQuery } from '../../utils/utils.queries';
@@ -30,7 +31,7 @@ import { NodePageStorage } from './NodePageStorage';
 export function NodePage() {
   const styles = useStyles2(getStyles);
   const { node } = useParams<{ node: string }>();
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activeTab, setActiveTab] = useActiveTab('overview');
 
   if (!node) {
     return <Alert title="Node not found" severity="error" />;

--- a/src/components/pods/PodPage.tsx
+++ b/src/components/pods/PodPage.tsx
@@ -10,11 +10,12 @@ import {
   TimeRangePicker,
 } from '@grafana/scenes-react';
 import { Alert, Badge, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
-import React, { useState } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ROUTES } from '../../constants';
 import datasourcePluginJson from '../../datasource/plugin.json';
+import { useActiveTab } from '../../hooks/useActiveTab';
 import resourcesImg from '../../img/logo.svg';
 import pluginJson from '../../plugin.json';
 import { queries, variableQuery } from '../../utils/utils.queries';
@@ -31,7 +32,7 @@ import { PodPageStorage } from './PodPageStorage';
 export function PodPage() {
   const styles = useStyles2(getStyles);
   const { namespace, pod } = useParams<{ namespace: string; pod: string }>();
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activeTab, setActiveTab] = useActiveTab('overview');
 
   if (!namespace) {
     return <Alert title="Namespace not found" severity="error" />;

--- a/src/components/workloads/WorkloadPage.tsx
+++ b/src/components/workloads/WorkloadPage.tsx
@@ -10,11 +10,12 @@ import {
   TimeRangePicker,
 } from '@grafana/scenes-react';
 import { Alert, Badge, Stack, Tab, TabsBar, useStyles2 } from '@grafana/ui';
-import React, { useState } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ROUTES } from '../../constants';
 import datasourcePluginJson from '../../datasource/plugin.json';
+import { useActiveTab } from '../../hooks/useActiveTab';
 import resourcesImg from '../../img/logo.svg';
 import pluginJson from '../../plugin.json';
 import { queries, variableQuery } from '../../utils/utils.queries';
@@ -35,7 +36,7 @@ export function WorkloadPage() {
     workloadType: string;
     workload: string;
   }>();
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activeTab, setActiveTab] = useActiveTab('overview');
 
   if (!namespace) {
     return <Alert title="Namespace not found" severity="error" />;

--- a/src/hooks/useActiveTab.tsx
+++ b/src/hooks/useActiveTab.tsx
@@ -1,0 +1,22 @@
+import { useSearchParams } from 'react-router-dom';
+
+export function useActiveTab(
+  defaultTab: string,
+  paramName = 'tab',
+): [string, (tab: string) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get(paramName) ?? defaultTab;
+
+  const setActiveTab = (tab: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set(paramName, tab);
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  return [activeTab, setActiveTab];
+}


### PR DESCRIPTION
Persist the users active tab in the url via a `tab` query parameter, so
that when the url is shared / the site is reloaded, the user will be
taken to the same tab they were on before.
