### PR TITLE
feat(grafana): make service account role configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ Afterwards you have to provide a Grafana username and password for the plugin,
 so that the plugin can interact with the Grafana API. The provided user should
 have the `Admin` role.
 
+You can also configure the role (`Admin`, `Editor` or `Viewer`) which is
+assigned to the Grafana service accounts that are created for each user when the
+**Generate Kubeconfig** feature is enabled. This role only affects the
+permissions of the service account inside Grafana, it does not change the
+Kubernetes permissions. The role defaults to `Viewer`.
+
 ### Impersonate
 
 The plugin can impersonate a Grafana user and the groups of the user when making

--- a/pkg/grafana/client.go
+++ b/pkg/grafana/client.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	serviceAccountPrefix = "kubernetes-"
+	serviceAccountPrefix      = "kubernetes-"
+	defaultServiceAccountRole = "Viewer"
 )
 
 type Client interface {
@@ -38,6 +39,7 @@ type Client interface {
 type client struct {
 	impersonateUser      bool
 	impersonateGroups    bool
+	serviceAccountRole   string
 	appUrl               *url.URL
 	client               *goapi.GrafanaHTTPAPI
 	usersCache           *expirable.LRU[int64, string]
@@ -45,7 +47,7 @@ type client struct {
 	groupsCache          *expirable.LRU[string, []string]
 }
 
-func NewClient(ctx context.Context, impersonateUser, impersonateGroups bool, username, password string) (Client, error) {
+func NewClient(ctx context.Context, impersonateUser, impersonateGroups bool, username, password, serviceAccountRole string) (Client, error) {
 	pCtx := backend.PluginConfigFromContext(ctx)
 
 	grafanaAppUrl, err := pCtx.GrafanaConfig.AppURL()
@@ -77,10 +79,18 @@ func NewClient(ctx context.Context, impersonateUser, impersonateGroups bool, use
 	serviceAccountsCache := expirable.NewLRU[int64, string](100, nil, 60*time.Minute)
 	groupsCache := expirable.NewLRU[string, []string](100, nil, 60*time.Minute)
 
+	// The service account role used when creating new service accounts for
+	// users defaults to "Viewer" when no role is configured in the data
+	// source settings.
+	if serviceAccountRole == "" {
+		serviceAccountRole = defaultServiceAccountRole
+	}
+
 	return &client{
-		impersonateUser:   impersonateUser,
-		impersonateGroups: impersonateGroups,
-		appUrl:            parsedGrafanaAppUrl,
+		impersonateUser:    impersonateUser,
+		impersonateGroups:  impersonateGroups,
+		serviceAccountRole: serviceAccountRole,
+		appUrl:             parsedGrafanaAppUrl,
 		client: goapi.NewHTTPClientWithConfig(strfmt.Default, &goapi.TransportConfig{
 			Host:      parsedGrafanaAppUrl.Host,
 			BasePath:  strings.TrimLeft(parsedGrafanaAppUrl.Path+"/api", "/"),
@@ -368,7 +378,7 @@ func (c *client) getServiceAccount(ctx context.Context, user string) (*models.Se
 		Body: &models.CreateServiceAccountForm{
 			IsDisabled: false,
 			Name:       user,
-			Role:       "Viewer",
+			Role:       c.serviceAccountRole,
 		},
 		Context: ctx,
 	})

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -18,6 +18,7 @@ type PluginSettings struct {
 	ClusterPath                      string                `json:"clusterPath"`
 	ClusterContext                   string                `json:"clusterContext"`
 	GrafanaUsername                  string                `json:"grafanaUsername"`
+	GrafanaServiceAccountRole        string                `json:"grafanaServiceAccountRole"`
 	ImpersonateUser                  bool                  `json:"impersonateUser"`
 	ImpersonateGroups                bool                  `json:"impersonateGroups"`
 	GenerateKubeconfig               bool                  `json:"generateKubeconfig"`

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -57,7 +57,7 @@ func NewDatasource(ctx context.Context, pCtx backend.DataSourceInstanceSettings)
 		return nil, err
 	}
 
-	grafanaClient, err := grafana.NewClient(ctx, config.ImpersonateUser, config.ImpersonateGroups, config.GrafanaUsername, config.Secrets.GrafanaPassword)
+	grafanaClient, err := grafana.NewClient(ctx, config.ImpersonateUser, config.ImpersonateGroups, config.GrafanaUsername, config.Secrets.GrafanaPassword, config.GrafanaServiceAccountRole)
 	if err != nil {
 		logger.Error("Failed to create Grafana client", "error", err.Error())
 		return nil, err

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -14,6 +14,7 @@ datasources:
       clusterPath: /kubeconfig.yaml
       clusterContext: default
       grafanaUsername: admin
+      grafanaServiceAccountRole: Viewer
       impersonateUser: false
       impersonateGroups: false
       generateKubeconfig: true

--- a/src/datasource/components/configeditor/Grafana.tsx
+++ b/src/datasource/components/configeditor/Grafana.tsx
@@ -3,19 +3,25 @@ import {
   DataSourcePluginOptionsEditorProps,
   GrafanaTheme2,
 } from '@grafana/data';
-import { InlineField, Input, SecretInput, useStyles2 } from '@grafana/ui';
+import {
+  InlineField,
+  Input,
+  RadioButtonGroup,
+  SecretInput,
+  useStyles2,
+} from '@grafana/ui';
 import React, { ChangeEvent } from 'react';
 
 import {
   DataSourceOptions,
+  GrafanaServiceAccountRole,
   KubernetesSecureJsonData,
 } from '../../types/settings';
 
-interface Props
-  extends DataSourcePluginOptionsEditorProps<
-    DataSourceOptions,
-    KubernetesSecureJsonData
-  > { }
+interface Props extends DataSourcePluginOptionsEditorProps<
+  DataSourceOptions,
+  KubernetesSecureJsonData
+> { }
 
 export function Grafana({ options, onOptionsChange }: Props) {
   const styles = useStyles2((theme: GrafanaTheme2) => {
@@ -70,6 +76,25 @@ export function Grafana({ options, onOptionsChange }: Props) {
             });
           }}
           width={65}
+        />
+      </InlineField>
+      <InlineField label="Service Account Role" labelWidth={20} interactive>
+        <RadioButtonGroup<GrafanaServiceAccountRole>
+          options={[
+            { label: 'Admin', value: 'Admin' },
+            { label: 'Editor', value: 'Editor' },
+            { label: 'Viewer', value: 'Viewer' },
+          ]}
+          value={options.jsonData.grafanaServiceAccountRole ?? 'Viewer'}
+          onChange={(value: GrafanaServiceAccountRole) => {
+            onOptionsChange({
+              ...options,
+              jsonData: {
+                ...options.jsonData,
+                grafanaServiceAccountRole: value,
+              },
+            });
+          }}
         />
       </InlineField>
     </div>

--- a/src/datasource/types/settings.ts
+++ b/src/datasource/types/settings.ts
@@ -8,6 +8,13 @@ import { DataSourceJsonData } from '@grafana/data';
 export type ClusterProvider = 'incluster' | 'path' | 'kubeconfig';
 
 /**
+ * GrafanaServiceAccountRole defines the role which is assigned to the Grafana
+ * service accounts that the plugin creates for each user when generating a
+ * kubeconfig.
+ */
+export type GrafanaServiceAccountRole = 'Admin' | 'Editor' | 'Viewer';
+
+/**
  * These are options configured for each DataSource instance. A user must select
  * a provider and depending on the selected provider a user must provide the
  * path to a Kubeconfig or upload a Kubeconfig.
@@ -17,6 +24,7 @@ export interface DataSourceOptions extends DataSourceJsonData {
   clusterPath?: string;
   clusterContext?: string;
   grafanaUsername?: string;
+  grafanaServiceAccountRole?: GrafanaServiceAccountRole;
   impersonateUser?: boolean;
   impersonateGroups?: boolean;
   generateKubeconfig?: boolean;


### PR DESCRIPTION
The service account role can now be configured. Until now the service
account was always created with the `Viewer` role, now it is also
possible to create the service account with the `Editor` or `Admin`
role.
