### PR TITLE
feat(workloads): add containers section to overview page

### DIFF
--- a/src/components/shared/TimeSeriesMemoryOrCPUByContainer.tsx
+++ b/src/components/shared/TimeSeriesMemoryOrCPUByContainer.tsx
@@ -1,0 +1,150 @@
+import { SceneDataQuery, VizConfigBuilders } from '@grafana/scenes';
+import { useQueryRunner, VizPanel } from '@grafana/scenes-react';
+import { LegendDisplayMode } from '@grafana/schema';
+import React from 'react';
+
+import { useVizPanelMenu } from '../../hooks/useVizPanelMenu';
+
+interface Props {
+  title: string;
+  unit: string;
+  limitsExpr?: string;
+  requestsExpr?: string;
+  usageAvgExpr?: string;
+  usageMaxExpr?: string;
+  usageMinExpr?: string;
+}
+
+export function TimeSeriesMemoryOrCPUByContainer({
+  title,
+  unit,
+  limitsExpr,
+  requestsExpr,
+  usageAvgExpr,
+  usageMaxExpr,
+  usageMinExpr,
+}: Props) {
+  const queries: SceneDataQuery[] = [];
+
+  if (limitsExpr) {
+    queries.push({
+      refId: 'limits',
+      format: 'time_series',
+      expr: limitsExpr,
+      legendFormat: 'Limits',
+    });
+  }
+  if (requestsExpr) {
+    queries.push({
+      refId: 'requests',
+      format: 'time_series',
+      expr: requestsExpr,
+      legendFormat: 'Requests',
+    });
+  }
+  if (usageAvgExpr) {
+    queries.push({
+      refId: 'avg',
+      format: 'time_series',
+      expr: usageAvgExpr,
+      legendFormat: 'Avg',
+    });
+  }
+  if (usageMaxExpr) {
+    queries.push({
+      refId: 'max',
+      format: 'time_series',
+      expr: usageMaxExpr,
+      legendFormat: 'Max',
+    });
+  }
+  if (usageMinExpr) {
+    queries.push({
+      refId: 'min',
+      format: 'time_series',
+      expr: usageMinExpr,
+      legendFormat: 'Min',
+    });
+  }
+
+  const dataProvider = useQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: '$prometheus',
+    },
+    queries: queries,
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setUnit(unit)
+    .setOption('legend', {
+      asTable: true,
+      displayMode: LegendDisplayMode.Table,
+      placement: 'bottom',
+      calcs: ['min', 'mean', 'max', 'lastNotNull'],
+    })
+    .setCustomFieldConfig('lineWidth', 2)
+    .setCustomFieldConfig('spanNulls', true)
+    .setOverrides((b) =>
+      b
+        .matchFieldsByQuery('limits')
+        .overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+        .overrideCustomFieldConfig('lineStyle', {
+          dash: [10, 10],
+          fill: 'dash',
+        }),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsByQuery('requests')
+        .overrideColor({
+          mode: 'fixed',
+          fixedColor: 'orange',
+        })
+        .overrideCustomFieldConfig('lineStyle', {
+          dash: [10, 10],
+          fill: 'dash',
+        }),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsByQuery('avg')
+        .overrideColor({
+          mode: 'fixed',
+          fixedColor: 'blue',
+        })
+        .overrideCustomFieldConfig('fillBelowTo', 'Min'),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsByQuery('max')
+        .overrideColor({
+          mode: 'fixed',
+          fixedColor: 'blue',
+        })
+        .overrideCustomFieldConfig('fillBelowTo', 'Avg')
+        .overrideCustomFieldConfig('lineWidth', 0),
+    )
+    .setOverrides((b) =>
+      b
+        .matchFieldsByQuery('min')
+        .overrideColor({
+          mode: 'fixed',
+          fixedColor: 'blue',
+        })
+        .overrideCustomFieldConfig('lineWidth', 0),
+    )
+    .build();
+
+  const menu = useVizPanelMenu({
+    data: dataProvider.useState(),
+    viz,
+  });
+
+  return (
+    <VizPanel title={title} menu={menu} viz={viz} dataProvider={dataProvider} />
+  );
+}

--- a/src/components/workloads/WorkloadPage.tsx
+++ b/src/components/workloads/WorkloadPage.tsx
@@ -156,157 +156,178 @@ export function WorkloadPage() {
                         sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                       >
                         <QueryVariable
-                          name="pvc"
-                          label="PersistentVolumeClaim"
+                          name="container"
+                          label="Container"
                           datasource={{
                             type: 'prometheus',
                             uid: '$prometheus',
                           }}
                           query={{
-                            refId: 'pvcs',
+                            refId: 'containers',
                             query: variableQuery(
-                              queries.persistentVolumeClaims
-                                .labelsByClusterNamespacePod,
+                              queries.containers.labelsByClusterNamespacePod,
                             ),
                           }}
                           refresh={VariableRefresh.onTimeRangeChanged}
-                          isMulti={true}
-                          includeAll={true}
-                          initialValue={'$__all'}
+                          isMulti={false}
+                          includeAll={false}
                           sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                         >
-                          <AnnotationLayer
-                            name="Restarts"
-                            query={{
-                              datasource: {
-                                type: 'prometheus',
-                                uid: '$prometheus',
-                              },
-                              enable: true,
-                              iconColor: 'orange',
-                              name: 'Restarts',
-                              textFormat: '{{pod}} restarted',
-                              target: {
-                                // @ts-ignore
-                                expr: queries.pods.restarts,
-                                limit: 100,
-                                matchAny: false,
-                                refId: 'Anno',
-                                type: 'dashboard',
-                              },
+                          <QueryVariable
+                            name="pvc"
+                            label="PersistentVolumeClaim"
+                            datasource={{
+                              type: 'prometheus',
+                              uid: '$prometheus',
                             }}
+                            query={{
+                              refId: 'pvcs',
+                              query: variableQuery(
+                                queries.persistentVolumeClaims
+                                  .labelsByClusterNamespacePod,
+                              ),
+                            }}
+                            refresh={VariableRefresh.onTimeRangeChanged}
+                            isMulti={true}
+                            includeAll={true}
+                            initialValue={'$__all'}
+                            sort={VariableSort.alphabeticalCaseInsensitiveAsc}
                           >
-                            <PluginPage
-                              pageNav={{
-                                text: workload,
-                                parentItem: {
-                                  text: namespace,
-                                  url: `${prefixRoute(ROUTES.Namespaces)}/${namespace}`,
-                                  parentItem: {
-                                    text: 'Workloads',
-                                    url: prefixRoute(ROUTES.Workloads),
-                                  },
+                            <AnnotationLayer
+                              name="Restarts"
+                              query={{
+                                datasource: {
+                                  type: 'prometheus',
+                                  uid: '$prometheus',
+                                },
+                                enable: true,
+                                iconColor: 'orange',
+                                name: 'Restarts',
+                                textFormat: '{{pod}} restarted',
+                                target: {
+                                  // @ts-ignore
+                                  expr: queries.pods.restarts,
+                                  limit: 100,
+                                  matchAny: false,
+                                  refId: 'Anno',
+                                  type: 'dashboard',
                                 },
                               }}
-                              renderTitle={() => (
-                                <Stack
-                                  gap={0}
-                                  alignItems="center"
-                                  direction="row"
-                                >
-                                  <img
-                                    className={styles.pluginPage.title.image}
-                                    alt={workload}
-                                    src={resourcesImg}
-                                  />
-                                  <h1>{workload}</h1>
-                                  <Badge
-                                    className={styles.pluginPage.title.badge}
-                                    color="blue"
-                                    text={workloadType.toLowerCase()}
-                                  />
-                                </Stack>
-                              )}
-                              subTitle={pluginJson.info.description}
-                              actions={
-                                <>
-                                  <TimeRangePicker />
-                                  <RefreshPicker />
-                                  <PageOptions />
-                                </>
-                              }
                             >
-                              <TabsBar className={styles.dashboard.tabsBar}>
-                                <Tab
-                                  label="Overview"
-                                  active={activeTab === 'overview'}
-                                  onChangeTab={(ev) => {
-                                    ev?.preventDefault();
-                                    setActiveTab('overview');
-                                  }}
-                                />
-                                <Tab
-                                  label="CPU"
-                                  active={activeTab === 'cpu'}
-                                  onChangeTab={(ev) => {
-                                    ev?.preventDefault();
-                                    setActiveTab('cpu');
-                                  }}
-                                />
-                                <Tab
-                                  label="Memory"
-                                  active={activeTab === 'memory'}
-                                  onChangeTab={(ev) => {
-                                    ev?.preventDefault();
-                                    setActiveTab('memory');
-                                  }}
-                                />
-                                <Tab
-                                  label="Network"
-                                  active={activeTab === 'network'}
-                                  onChangeTab={(ev) => {
-                                    ev?.preventDefault();
-                                    setActiveTab('network');
-                                  }}
-                                />
-                                <Tab
-                                  label="Storage"
-                                  active={activeTab === 'storage'}
-                                  onChangeTab={(ev) => {
-                                    ev?.preventDefault();
-                                    setActiveTab('storage');
-                                  }}
-                                />
-                                <Tab
-                                  label="Logs"
-                                  active={activeTab === 'logs'}
-                                  onChangeTab={(ev) => {
-                                    ev?.preventDefault();
-                                    setActiveTab('logs');
-                                  }}
-                                />
-                              </TabsBar>
-                              {activeTab === 'overview' && (
-                                <WorkloadPageOverview
-                                  workloadType={workloadType.toLowerCase()}
-                                />
-                              )}
-                              {activeTab === 'cpu' && <WorkloadPageCPU />}
-                              {activeTab === 'memory' && <WorkloadPageMemory />}
-                              {activeTab === 'network' && (
-                                <WorkloadPageNetwork />
-                              )}
-                              {activeTab === 'storage' && (
-                                <WorkloadPageStorage />
-                              )}
-                              {activeTab === 'logs' && (
-                                <TabLogs
-                                  page="workload"
-                                  resource={workloadType}
-                                />
-                              )}
-                            </PluginPage>
-                          </AnnotationLayer>
+                              <PluginPage
+                                pageNav={{
+                                  text: workload,
+                                  parentItem: {
+                                    text: namespace,
+                                    url: `${prefixRoute(ROUTES.Namespaces)}/${namespace}`,
+                                    parentItem: {
+                                      text: 'Workloads',
+                                      url: prefixRoute(ROUTES.Workloads),
+                                    },
+                                  },
+                                }}
+                                renderTitle={() => (
+                                  <Stack
+                                    gap={0}
+                                    alignItems="center"
+                                    direction="row"
+                                  >
+                                    <img
+                                      className={styles.pluginPage.title.image}
+                                      alt={workload}
+                                      src={resourcesImg}
+                                    />
+                                    <h1>{workload}</h1>
+                                    <Badge
+                                      className={styles.pluginPage.title.badge}
+                                      color="blue"
+                                      text={workloadType.toLowerCase()}
+                                    />
+                                  </Stack>
+                                )}
+                                subTitle={pluginJson.info.description}
+                                actions={
+                                  <>
+                                    <TimeRangePicker />
+                                    <RefreshPicker />
+                                    <PageOptions />
+                                  </>
+                                }
+                              >
+                                <TabsBar className={styles.dashboard.tabsBar}>
+                                  <Tab
+                                    label="Overview"
+                                    active={activeTab === 'overview'}
+                                    onChangeTab={(ev) => {
+                                      ev?.preventDefault();
+                                      setActiveTab('overview');
+                                    }}
+                                  />
+                                  <Tab
+                                    label="CPU"
+                                    active={activeTab === 'cpu'}
+                                    onChangeTab={(ev) => {
+                                      ev?.preventDefault();
+                                      setActiveTab('cpu');
+                                    }}
+                                  />
+                                  <Tab
+                                    label="Memory"
+                                    active={activeTab === 'memory'}
+                                    onChangeTab={(ev) => {
+                                      ev?.preventDefault();
+                                      setActiveTab('memory');
+                                    }}
+                                  />
+                                  <Tab
+                                    label="Network"
+                                    active={activeTab === 'network'}
+                                    onChangeTab={(ev) => {
+                                      ev?.preventDefault();
+                                      setActiveTab('network');
+                                    }}
+                                  />
+                                  <Tab
+                                    label="Storage"
+                                    active={activeTab === 'storage'}
+                                    onChangeTab={(ev) => {
+                                      ev?.preventDefault();
+                                      setActiveTab('storage');
+                                    }}
+                                  />
+                                  <Tab
+                                    label="Logs"
+                                    active={activeTab === 'logs'}
+                                    onChangeTab={(ev) => {
+                                      ev?.preventDefault();
+                                      setActiveTab('logs');
+                                    }}
+                                  />
+                                </TabsBar>
+                                {activeTab === 'overview' && (
+                                  <WorkloadPageOverview
+                                    workloadType={workloadType.toLowerCase()}
+                                  />
+                                )}
+                                {activeTab === 'cpu' && <WorkloadPageCPU />}
+                                {activeTab === 'memory' && (
+                                  <WorkloadPageMemory />
+                                )}
+                                {activeTab === 'network' && (
+                                  <WorkloadPageNetwork />
+                                )}
+                                {activeTab === 'storage' && (
+                                  <WorkloadPageStorage />
+                                )}
+                                {activeTab === 'logs' && (
+                                  <TabLogs
+                                    page="workload"
+                                    resource={workloadType}
+                                  />
+                                )}
+                              </PluginPage>
+                            </AnnotationLayer>
+                          </QueryVariable>
                         </QueryVariable>
                       </QueryVariable>
                     </CustomVariable>

--- a/src/components/workloads/WorkloadPageOverview.tsx
+++ b/src/components/workloads/WorkloadPageOverview.tsx
@@ -8,6 +8,7 @@ import {
 import { RadioButtonGroup, Stack, useStyles2 } from '@grafana/ui';
 import React, { useState } from 'react';
 
+import { TimeSeriesMemoryOrCPUByContainer } from 'components/shared/TimeSeriesMemoryOrCPUByContainer';
 import datasourcePluginJson from '../../datasource/plugin.json';
 import { useVizPanelMenu } from '../../hooks/useVizPanelMenu';
 import { queries } from '../../utils/utils.queries';
@@ -239,6 +240,8 @@ export function WorkloadPageOverview({ workloadType }: Props) {
 
       <Pods />
 
+      <Containers />
+
       {workloadType === 'cronjob' && <Jobs />}
     </Stack>
   );
@@ -295,6 +298,41 @@ function Pods() {
             />
           )}
           {selected === 'info' && <TableKubernetesPods />}
+        </div>
+      </Stack>
+    </div>
+  );
+}
+
+function Containers() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.pluginPage.section}>
+      <h4>Containers</h4>
+      <Stack direction="column" gap={2}>
+        <div className={styles.dashboard.header.container}>
+          <VariableControl name="container" />
+        </div>
+        <div className={styles.dashboard.row.height400px}>
+          <TimeSeriesMemoryOrCPUByContainer
+            title="CPU Usage"
+            unit="cores"
+            limitsExpr={queries.workloads.cpuLimitsByContainer}
+            requestsExpr={queries.workloads.cpuRequestsByContainer}
+            usageAvgExpr={queries.workloads.cpuUsageAvgByContainer}
+            usageMaxExpr={queries.workloads.cpuUsageMaxByContainer}
+            usageMinExpr={queries.workloads.cpuUsageMinByContainer}
+          />
+          <TimeSeriesMemoryOrCPUByContainer
+            title="Memory Usage"
+            unit="bytes"
+            limitsExpr={queries.workloads.memoryLimitsByContainer}
+            requestsExpr={queries.workloads.memoryRequestsByContainer}
+            usageAvgExpr={queries.workloads.memoryUsageAvgByContainer}
+            usageMaxExpr={queries.workloads.memoryUsageMaxByContainer}
+            usageMinExpr={queries.workloads.memoryUsageMinByContainer}
+          />
         </div>
       </Stack>
     </div>

--- a/src/utils/utils.queries.ts
+++ b/src/utils/utils.queries.ts
@@ -4428,6 +4428,86 @@ label_join(
     cluster=~"$cluster",namespace=~".+",workload=~"$searchterm"
   }
 ) by(namespace,workload,workload_type)`,
+    cpuLimitsByContainer: `max(
+  cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{
+    cluster=~"$cluster",
+    namespace=~"$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by(container)`,
+    cpuRequestsByContainer: `max(
+  cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{
+    cluster=~"$cluster",
+    namespace=~"$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by(container)`,
+    cpuUsageAvgByContainer: `avg(
+  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{
+    cluster=~"$cluster",
+    namespace=~"$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by(container)`,
+    cpuUsageMaxByContainer: `max(
+  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{
+    cluster=~"$cluster",
+    namespace=~"$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by(container)`,
+    cpuUsageMinByContainer: `min(
+  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{
+    cluster=~"$cluster",
+    namespace=~"$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by(container)`,
+    memoryLimitsByContainer: `max(
+  cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{
+    cluster=~"$cluster",
+    namespace=~"$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by (container)`,
+    memoryRequestsByContainer: `max(
+  cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{
+    cluster=~"$cluster",
+    namespace=~"$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by(container)`,
+    memoryUsageAvgByContainer: `avg(
+  container_memory_working_set_bytes{
+    cluster=~"$cluster",
+    namespace="$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by(container)`,
+    memoryUsageMaxByContainer: `max(
+  container_memory_working_set_bytes{
+    cluster=~"$cluster",
+    namespace="$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by(container)`,
+    memoryUsageMinByContainer: `min(
+  container_memory_working_set_bytes{
+    cluster=~"$cluster",
+    namespace="$namespace",
+    pod=~"$pod",
+    container="$container"
+  }
+) by(container)`,
   },
   pods: {
     count: `count(kube_pod_info{cluster=~"$cluster", namespace=~"$namespace", pod!=""})`,


### PR DESCRIPTION
The new containers section on the overview page of a workloads shows the
min/max/avg CPU and memory usage of a selected container of this
workload, across all Pods. The time series graphs also include the
requests and limits of the selected container.
